### PR TITLE
Feature/reference library

### DIFF
--- a/backend/alembic/versions/knowledge_gap_signals_0001.py
+++ b/backend/alembic/versions/knowledge_gap_signals_0001.py
@@ -1,0 +1,42 @@
+"""Knowledge gap signals (curatorial pull loop).
+
+Records questions the reference library could not answer, so curators know what
+authoritative content is missing. Written by the domain-Q&A path.
+
+Revision ID: knowledge_gap_signals_0001
+Revises: reference_library_0001
+Create Date: 2026-06-08
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "knowledge_gap_signals_0001"
+down_revision = "reference_library_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "knowledge_gap_signals",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("query", sa.Text(), nullable=False),
+        sa.Column("vertical", sa.Text(), nullable=True),
+        sa.Column("filters", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_knowledge_gap_signals_created_at "
+        "ON knowledge_gap_signals (created_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_knowledge_gap_signals_created_at", table_name="knowledge_gap_signals")
+    op.drop_table("knowledge_gap_signals")

--- a/backend/alembic/versions/reference_library_0001.py
+++ b/backend/alembic/versions/reference_library_0001.py
@@ -1,0 +1,82 @@
+"""Reference library (Knowledge Slot) tables.
+
+Adds the sponsor-curated domain-knowledge store, kept separate from the
+participant-document store. Two-table design: reference_documents (parent,
+document-level + provenance metadata) and reference_chunks (searchable text +
+embedding + controlled-vocabulary metadata). Natural keys (doc_key, chunk_id)
+come from the KnowledgeSlot pipeline so ingestion is idempotent.
+
+Revision ID: reference_library_0001
+Revises: mkt_5ed8adda2d87
+Create Date: 2026-06-08
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "reference_library_0001"
+down_revision = "mkt_5ed8adda2d87"
+branch_labels = None
+depends_on = None
+
+EMBEDDING_DIM = 1536
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    op.create_table(
+        "reference_documents",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("doc_key", sa.Text(), nullable=False),
+        sa.Column("vertical", sa.Text(), nullable=False, server_default="default"),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("source_document", sa.Text(), nullable=True),
+        sa.Column("source_url", sa.Text(), nullable=True),
+        sa.Column("doc_metadata", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.UniqueConstraint("doc_key", name="uq_reference_documents_doc_key"),
+    )
+    op.create_index("ix_reference_documents_vertical", "reference_documents", ["vertical"])
+
+    op.create_table(
+        "reference_chunks",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("document_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("chunk_id", sa.Text(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("contextual_content", sa.Text(), nullable=False),
+        sa.Column("embedding", Vector(EMBEDDING_DIM), nullable=False),
+        sa.Column("chunk_metadata", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.ForeignKeyConstraint(
+            ["document_id"], ["reference_documents.id"],
+            name="fk_reference_chunks_document_id", ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("chunk_id", name="uq_reference_chunks_chunk_id"),
+    )
+    op.create_index("ix_reference_chunks_document_id", "reference_chunks", ["document_id"])
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_reference_chunks_metadata_gin "
+        "ON reference_chunks USING gin (chunk_metadata jsonb_path_ops)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_reference_chunks_embedding "
+        "ON reference_chunks USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_reference_chunks_embedding", table_name="reference_chunks")
+    op.drop_index("ix_reference_chunks_metadata_gin", table_name="reference_chunks")
+    op.drop_index("ix_reference_chunks_document_id", table_name="reference_chunks")
+    op.drop_table("reference_chunks")
+    op.drop_index("ix_reference_documents_vertical", table_name="reference_documents")
+    op.drop_table("reference_documents")

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -618,6 +618,13 @@ async def _ensure_indexes(conn) -> None:
             "ON reference_chunks USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)"
         )
     )
+    # Knowledge gap signals: curators read newest-first.
+    await conn.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_knowledge_gap_signals_created_at "
+            "ON knowledge_gap_signals (created_at DESC)"
+        )
+    )
 
     # Cleanup stale vector rows before enforcing referential integrity.
     await conn.execute(

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -591,6 +591,34 @@ async def _ensure_indexes(conn) -> None:
         text("CREATE INDEX IF NOT EXISTS ix_ai_document_chunks_document_id ON ai_document_chunks (document_id)")
     )
 
+    # Reference library (Knowledge Slot) indexes.
+    await conn.execute(
+        text("CREATE UNIQUE INDEX IF NOT EXISTS uq_reference_documents_doc_key ON reference_documents (doc_key)")
+    )
+    await conn.execute(
+        text("CREATE INDEX IF NOT EXISTS ix_reference_documents_vertical ON reference_documents (vertical)")
+    )
+    await conn.execute(
+        text("CREATE UNIQUE INDEX IF NOT EXISTS uq_reference_chunks_chunk_id ON reference_chunks (chunk_id)")
+    )
+    await conn.execute(
+        text("CREATE INDEX IF NOT EXISTS ix_reference_chunks_document_id ON reference_chunks (document_id)")
+    )
+    # GIN with jsonb_path_ops: smaller/faster for the @> containment pre-filter
+    # used by metadata-filtered retrieval (jurisdiction/topic/doc_type).
+    await conn.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_reference_chunks_metadata_gin "
+            "ON reference_chunks USING gin (chunk_metadata jsonb_path_ops)"
+        )
+    )
+    await conn.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_reference_chunks_embedding "
+            "ON reference_chunks USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)"
+        )
+    )
+
     # Cleanup stale vector rows before enforcing referential integrity.
     await conn.execute(
         text(
@@ -633,6 +661,29 @@ async def _ensure_indexes(conn) -> None:
                     ALTER TABLE profile_vectors
                     ADD CONSTRAINT fk_profile_vectors_profile_id
                     FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE;
+                END IF;
+            END
+            $$;
+            """
+        )
+    )
+    await conn.execute(
+        text(
+            "DELETE FROM reference_chunks c "
+            "WHERE NOT EXISTS (SELECT 1 FROM reference_documents d WHERE d.id = c.document_id)"
+        )
+    )
+    await conn.execute(
+        text(
+            """
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint WHERE conname = 'fk_reference_chunks_document_id'
+                ) THEN
+                    ALTER TABLE reference_chunks
+                    ADD CONSTRAINT fk_reference_chunks_document_id
+                    FOREIGN KEY (document_id) REFERENCES reference_documents(id) ON DELETE CASCADE;
                 END IF;
             END
             $$;

--- a/backend/app/core/db_schema.py
+++ b/backend/app/core/db_schema.py
@@ -133,6 +133,21 @@ reference_chunks = Table(
     Column("updated_at", DateTime(timezone=True), nullable=False, server_default=text("NOW()")),
 )
 
+# Knowledge gap signals: questions the reference library could not answer.
+# The curatorial "pull signal" — tells curators what authoritative content is
+# missing. Written from the domain-Q&A path; read by curators via the admin API.
+knowledge_gap_signals = Table(
+    "knowledge_gap_signals",
+    metadata,
+    Column("id", UUID(as_uuid=True), primary_key=True, default=uuid.uuid4),
+    Column("query", Text, nullable=False),
+    Column("vertical", Text, nullable=True),
+    Column("filters", JSONB, nullable=False, server_default=text("'{}'::jsonb")),
+    # Why the gap was recorded: "no_matching_chunks" | "model_not_covered".
+    Column("reason", Text, nullable=False),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=text("NOW()")),
+)
+
 
 def table_for_collection(name: str) -> Table:
     table = DOC_TABLES.get(name)

--- a/backend/app/core/db_schema.py
+++ b/backend/app/core/db_schema.py
@@ -81,6 +81,58 @@ profile_vectors = Table(
     Column("updated_at", DateTime(timezone=True), nullable=False, server_default=text("NOW()")),
 )
 
+# ── Knowledge Slot / Reference Library ────────────────────────────────────────
+# Sponsor-curated domain knowledge, kept deliberately separate from the
+# participant-document store (ai_documents / ai_document_chunks). A two-table
+# design mirrors that pattern: a parent document row carries document-level,
+# provenance, and versioning metadata; each chunk row carries the searchable
+# text + embedding + controlled-vocabulary metadata produced by KnowledgeSlot.
+#
+# Natural keys (doc_key, chunk_id) come from the upstream KnowledgeSlot pipeline
+# so ingestion is idempotent: re-loading regenerated content upserts in place
+# rather than duplicating rows.
+
+REFERENCE_EMBEDDING_DIM = 1536  # text-embedding-3-small; must match Cosolvent's other vector tables.
+
+reference_documents = Table(
+    "reference_documents",
+    metadata,
+    Column("id", UUID(as_uuid=True), primary_key=True, default=uuid.uuid4),
+    # Stable natural key from the curation pipeline (e.g. the document stem "27_2025").
+    Column("doc_key", Text, nullable=False, unique=True),
+    Column("vertical", Text, nullable=False, server_default=text("'default'")),
+    Column("title", Text, nullable=True),
+    Column("source_document", Text, nullable=True),
+    Column("source_url", Text, nullable=True),
+    # Document-level metadata + provenance (doc_type, standard/standard_body,
+    # jurisdiction, version, fetched_at, issuing_organization, ...).
+    Column("doc_metadata", JSONB, nullable=False, server_default=text("'{}'::jsonb")),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=text("NOW()")),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=text("NOW()")),
+)
+
+reference_chunks = Table(
+    "reference_chunks",
+    metadata,
+    Column("id", UUID(as_uuid=True), primary_key=True, default=uuid.uuid4),
+    Column(
+        "document_id",
+        UUID(as_uuid=True),
+        ForeignKey("reference_documents.id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    # Natural key from the pipeline (e.g. "27_2025_0"); drives idempotent upsert.
+    Column("chunk_id", Text, nullable=False, unique=True),
+    Column("content", Text, nullable=False),
+    # Heading-prefixed text that is actually embedded ("[doc] H1 > H2 > body").
+    Column("contextual_content", Text, nullable=False),
+    Column("embedding", Vector(REFERENCE_EMBEDDING_DIM), nullable=False),
+    # Chunk-level controlled-vocabulary metadata (doc_type, standard, jurisdiction, topic, ...).
+    Column("chunk_metadata", JSONB, nullable=False, server_default=text("'{}'::jsonb")),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=text("NOW()")),
+    Column("updated_at", DateTime(timezone=True), nullable=False, server_default=text("NOW()")),
+)
+
 
 def table_for_collection(name: str) -> Table:
     table = DOC_TABLES.get(name)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -116,6 +116,7 @@ def _register_routers(application: FastAPI) -> None:
     from app.modules.communication.router import router as comms_router
     from app.modules.discovery.router import router as discovery_router
     from app.modules.files.router import router as files_router
+    from app.modules.knowledge.router import router as knowledge_router
     from app.modules.notifications.router import router as notif_router
     from app.modules.profiles.router import router as profiles_router
     from app.modules.setup.router import router as setup_router
@@ -127,6 +128,7 @@ def _register_routers(application: FastAPI) -> None:
     application.include_router(discovery_router, prefix="/api/search", tags=["discovery"])
     application.include_router(notif_router, prefix="/api/notifications", tags=["notifications"])
     application.include_router(ai_router, prefix="/api/ai", tags=["ai"])
+    application.include_router(knowledge_router, prefix="/api/knowledge", tags=["knowledge"])
     application.include_router(admin_router, prefix="/api/admin", tags=["admin"])
     application.include_router(setup_router, tags=["setup"])
 

--- a/backend/app/modules/knowledge/__init__.py
+++ b/backend/app/modules/knowledge/__init__.py
@@ -1,0 +1,7 @@
+"""Knowledge Slot — sponsor-curated reference library (documents + chunks).
+
+Stores authoritative domain knowledge (regulations, standards, contracts)
+ingested from the KnowledgeSlot curation pipeline, separate from the
+participant-document RAG store, and exposes metadata-filtered vector retrieval
+for domain Q&A.
+"""

--- a/backend/app/modules/knowledge/loader.py
+++ b/backend/app/modules/knowledge/loader.py
@@ -1,0 +1,99 @@
+"""Adapter: KnowledgeSlot ``*_processed.jsonl`` -> reference-library documents.
+
+The upstream pipeline emits one JSON object per line, each a chunk with
+``chunk_id``, ``content``, ``contextual_content``, ``metadata`` and a
+precomputed ``embedding``. This groups those flat chunk records back into
+parent documents so they can be ingested into the two-table model.
+
+`parse_records` is pure (no I/O) so it is unit-testable without a database.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.modules.knowledge.schemas import ReferenceChunkInput, ReferenceDocumentInput
+
+logger = logging.getLogger("cosolvent.knowledge")
+
+# Chunk-level metadata key that must NOT be promoted to the document level.
+_CHUNK_ONLY_KEYS = {"topic"}
+
+
+def _doc_key_for(record: dict[str, Any]) -> str:
+    """Derive a stable document key for a chunk record.
+
+    Prefers the ``source_document`` filename (minus extension); falls back to
+    stripping the trailing ``_<index>`` from the chunk_id (e.g. ``27_2025_0`` ->
+    ``27_2025``).
+    """
+    src = (record.get("metadata") or {}).get("source_document")
+    if src:
+        return Path(str(src)).stem
+    chunk_id = str(record.get("chunk_id", ""))
+    head, _, tail = chunk_id.rpartition("_")
+    return head if head and tail.isdigit() else chunk_id
+
+
+def _doc_metadata_from(chunk_meta: dict[str, Any]) -> dict[str, Any]:
+    """Extract the document-level fields from a chunk's metadata."""
+    return {k: v for k, v in chunk_meta.items() if k not in _CHUNK_ONLY_KEYS}
+
+
+def parse_records(records: Iterable[dict[str, Any]], vertical: str = "default") -> list[ReferenceDocumentInput]:
+    """Group flat chunk records into ReferenceDocumentInput objects (order-stable)."""
+    docs: dict[str, ReferenceDocumentInput] = {}
+
+    for record in records:
+        doc_key = _doc_key_for(record)
+        meta = record.get("metadata") or {}
+
+        if doc_key not in docs:
+            docs[doc_key] = ReferenceDocumentInput(
+                doc_key=doc_key,
+                vertical=vertical,
+                title=meta.get("title"),
+                source_document=meta.get("source_document") or f"{doc_key}.md",
+                source_url=meta.get("source_url"),
+                doc_metadata=_doc_metadata_from(meta),
+                chunks=[],
+            )
+
+        docs[doc_key].chunks.append(
+            ReferenceChunkInput(
+                chunk_id=record["chunk_id"],
+                content=record["content"],
+                contextual_content=record["contextual_content"],
+                metadata=meta,
+                embedding=record.get("embedding"),
+            )
+        )
+
+    return list(docs.values())
+
+
+def parse_jsonl_text(text: str, vertical: str = "default") -> list[ReferenceDocumentInput]:
+    """Parse newline-delimited JSON (skipping blank lines) into documents."""
+    records = [json.loads(line) for line in text.splitlines() if line.strip()]
+    return parse_records(records, vertical)
+
+
+def load_paths(paths: list[Path], vertical: str = "default") -> list[ReferenceDocumentInput]:
+    """Read one or more ``.jsonl`` files (or directories of them) into documents."""
+    files: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            files.extend(sorted(p.glob("*.jsonl")))
+        else:
+            files.append(p)
+
+    all_records: list[dict[str, Any]] = []
+    for f in files:
+        all_records.extend(
+            json.loads(line) for line in f.read_text(encoding="utf-8").splitlines() if line.strip()
+        )
+        logger.info("Parsed reference chunks from %s", f)
+    return parse_records(all_records, vertical)

--- a/backend/app/modules/knowledge/repository.py
+++ b/backend/app/modules/knowledge/repository.py
@@ -210,6 +210,16 @@ async def insert_gap_signal(
     return str(gap_id)
 
 
+# Upper bound on how many gap rows a single query may request, so an arbitrary
+# caller-supplied `limit` on the admin endpoint can't trigger an oversized read.
+_MAX_GAP_LIMIT = 500
+
+
+def bounded_gap_limit(limit: int) -> int:
+    """Clamp a requested gap-list limit into [1, _MAX_GAP_LIMIT]."""
+    return max(1, min(limit, _MAX_GAP_LIMIT))
+
+
 async def list_gap_signals(*, vertical: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
     """Newest-first list of recorded knowledge gaps (curator view)."""
     stmt: Select[Any] = select(knowledge_gap_signals).order_by(
@@ -217,7 +227,7 @@ async def list_gap_signals(*, vertical: str | None = None, limit: int = 100) -> 
     )
     if vertical:
         stmt = stmt.where(knowledge_gap_signals.c.vertical == vertical)
-    stmt = stmt.limit(max(1, limit))
+    stmt = stmt.limit(bounded_gap_limit(limit))
 
     async with session_scope() as session:
         rows = (await session.execute(stmt)).all()

--- a/backend/app/modules/knowledge/repository.py
+++ b/backend/app/modules/knowledge/repository.py
@@ -1,0 +1,213 @@
+"""Database access for the reference library (documents + chunks).
+
+Idempotent upserts keyed on the pipeline's natural keys (doc_key, chunk_id) so
+re-loading regenerated content updates in place, and a metadata-pre-filtered
+cosine-similarity retrieval over the chunk embeddings.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import Select, delete, false, or_, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.sql import func
+
+from app.core.database import session_scope
+from app.core.db_schema import reference_chunks, reference_documents
+
+logger = logging.getLogger("cosolvent.knowledge")
+
+
+async def upsert_document(
+    *,
+    doc_key: str,
+    vertical: str,
+    title: str | None,
+    source_document: str | None,
+    source_url: str | None,
+    doc_metadata: dict[str, Any],
+) -> uuid.UUID:
+    """Insert or update a reference document by its natural key. Returns its id."""
+    stmt = (
+        pg_insert(reference_documents)
+        .values(
+            id=uuid.uuid4(),
+            doc_key=doc_key,
+            vertical=vertical,
+            title=title,
+            source_document=source_document,
+            source_url=source_url,
+            doc_metadata=doc_metadata,
+        )
+        .on_conflict_do_update(
+            index_elements=["doc_key"],
+            set_={
+                "vertical": vertical,
+                "title": title,
+                "source_document": source_document,
+                "source_url": source_url,
+                "doc_metadata": doc_metadata,
+                "updated_at": func.now(),
+            },
+        )
+        .returning(reference_documents.c.id)
+    )
+    async with session_scope() as session:
+        result = await session.execute(stmt)
+        doc_id = result.scalar_one()
+        await session.commit()
+    return doc_id
+
+
+async def upsert_chunks(document_id: uuid.UUID, chunks: list[dict[str, Any]]) -> int:
+    """Insert or update chunks by chunk_id. Returns the number upserted."""
+    if not chunks:
+        return 0
+
+    rows = [
+        {
+            "id": uuid.uuid4(),
+            "document_id": document_id,
+            "chunk_id": c["chunk_id"],
+            "content": c["content"],
+            "contextual_content": c["contextual_content"],
+            "embedding": c["embedding"],
+            "chunk_metadata": c.get("metadata") or {},
+        }
+        for c in chunks
+    ]
+
+    stmt = pg_insert(reference_chunks).values(rows)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["chunk_id"],
+        set_={
+            "document_id": stmt.excluded.document_id,
+            "content": stmt.excluded.content,
+            "contextual_content": stmt.excluded.contextual_content,
+            "embedding": stmt.excluded.embedding,
+            "chunk_metadata": stmt.excluded.chunk_metadata,
+            "updated_at": func.now(),
+        },
+    )
+
+    async with session_scope() as session:
+        await session.execute(stmt)
+        await session.commit()
+    return len(rows)
+
+
+async def retrieve(
+    query_embedding: list[float],
+    *,
+    top_k: int = 8,
+    filters: dict[str, Any] | None = None,
+    vertical: str | None = None,
+    min_score: float = 0.0,
+) -> list[dict[str, Any]]:
+    """Metadata-pre-filtered cosine-similarity search over reference chunks.
+
+    Joins each chunk back to its parent document so results carry the citation
+    fields (doc_key, title, source_document).
+    """
+    distance = reference_chunks.c.embedding.cosine_distance(query_embedding)
+    similarity = 1 - distance
+    score = similarity.label("score")
+
+    stmt: Select[Any] = select(
+        reference_chunks.c.chunk_id,
+        reference_chunks.c.content,
+        reference_chunks.c.contextual_content,
+        reference_chunks.c.chunk_metadata,
+        reference_documents.c.doc_key,
+        reference_documents.c.title,
+        reference_documents.c.source_document,
+        score,
+    ).select_from(
+        reference_chunks.join(
+            reference_documents,
+            reference_documents.c.id == reference_chunks.c.document_id,
+        )
+    )
+
+    if vertical:
+        stmt = stmt.where(reference_documents.c.vertical == vertical)
+    if min_score > 0:
+        stmt = stmt.where(similarity >= min_score)
+
+    stmt = _apply_metadata_filters(stmt, reference_chunks.c.chunk_metadata, filters or {})
+    stmt = stmt.order_by(distance).limit(max(1, top_k))
+
+    async with session_scope() as session:
+        rows = (await session.execute(stmt)).all()
+
+    return [
+        {
+            "chunk_id": row.chunk_id,
+            "doc_key": row.doc_key,
+            "title": row.title,
+            "source_document": row.source_document,
+            "content": row.content,
+            "contextual_content": row.contextual_content,
+            "score": float(row.score),
+            "metadata": row.chunk_metadata or {},
+        }
+        for row in rows
+    ]
+
+
+async def delete_document(doc_key: str) -> bool:
+    """Delete a document and (via FK cascade) its chunks. Returns True if found."""
+    async with session_scope() as session:
+        result = await session.execute(
+            delete(reference_documents).where(reference_documents.c.doc_key == doc_key)
+        )
+        await session.commit()
+    return (result.rowcount or 0) > 0
+
+
+async def count_chunks(vertical: str | None = None) -> int:
+    stmt: Select[Any] = select(func.count()).select_from(reference_chunks)
+    if vertical:
+        stmt = (
+            select(func.count())
+            .select_from(
+                reference_chunks.join(
+                    reference_documents,
+                    reference_documents.c.id == reference_chunks.c.document_id,
+                )
+            )
+            .where(reference_documents.c.vertical == vertical)
+        )
+    async with session_scope() as session:
+        return int((await session.execute(stmt)).scalar_one())
+
+
+def _apply_metadata_filters(stmt: Select[Any], metadata_column: Any, filters: dict[str, Any]) -> Select[Any]:
+    """Apply JSONB containment filters with any-match semantics for list values.
+
+    Mirrors discovery.vector_service so reference-library filtering behaves
+    identically to participant search (scalar or array metadata fields).
+    """
+    for key, value in filters.items():
+        if value is None:
+            continue
+        if isinstance(value, list):
+            if not value:
+                stmt = stmt.where(false())
+                continue
+            conditions = [_json_field_any_match(metadata_column, key, option) for option in value]
+            stmt = stmt.where(or_(*conditions))
+        else:
+            stmt = stmt.where(_json_field_any_match(metadata_column, key, value))
+    return stmt
+
+
+def _json_field_any_match(column: Any, key: str, value: Any):
+    # Matches both scalar fields ({key: value}) and array fields ({key: [value]}).
+    return or_(
+        column.contains({key: value}),
+        column.contains({key: [value]}),
+    )

--- a/backend/app/modules/knowledge/repository.py
+++ b/backend/app/modules/knowledge/repository.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy import Select, delete, false, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.sql import func
 
 from app.core.database import session_scope
-from app.core.db_schema import reference_chunks, reference_documents
+from app.core.db_schema import knowledge_gap_signals, reference_chunks, reference_documents
 
 logger = logging.getLogger("cosolvent.knowledge")
 
@@ -165,7 +165,9 @@ async def delete_document(doc_key: str) -> bool:
             delete(reference_documents).where(reference_documents.c.doc_key == doc_key)
         )
         await session.commit()
-    return (result.rowcount or 0) > 0
+    # rowcount lives on the underlying CursorResult; the Result[Any] type hint
+    # doesn't expose it, so read it dynamically.
+    return (cast(Any, result).rowcount or 0) > 0
 
 
 async def count_chunks(vertical: str | None = None) -> int:
@@ -183,6 +185,54 @@ async def count_chunks(vertical: str | None = None) -> int:
         )
     async with session_scope() as session:
         return int((await session.execute(stmt)).scalar_one())
+
+
+async def insert_gap_signal(
+    *,
+    query: str,
+    vertical: str | None,
+    filters: dict[str, Any] | None,
+    reason: str,
+) -> str:
+    """Record a knowledge gap (question the library could not answer). Returns its id."""
+    gap_id = uuid.uuid4()
+    async with session_scope() as session:
+        await session.execute(
+            knowledge_gap_signals.insert().values(
+                id=gap_id,
+                query=query,
+                vertical=vertical,
+                filters=filters or {},
+                reason=reason,
+            )
+        )
+        await session.commit()
+    return str(gap_id)
+
+
+async def list_gap_signals(*, vertical: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    """Newest-first list of recorded knowledge gaps (curator view)."""
+    stmt: Select[Any] = select(knowledge_gap_signals).order_by(
+        knowledge_gap_signals.c.created_at.desc()
+    )
+    if vertical:
+        stmt = stmt.where(knowledge_gap_signals.c.vertical == vertical)
+    stmt = stmt.limit(max(1, limit))
+
+    async with session_scope() as session:
+        rows = (await session.execute(stmt)).all()
+
+    return [
+        {
+            "id": str(row.id),
+            "query": row.query,
+            "vertical": row.vertical,
+            "filters": row.filters or {},
+            "reason": row.reason,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
+        }
+        for row in rows
+    ]
 
 
 def _apply_metadata_filters(stmt: Select[Any], metadata_column: Any, filters: dict[str, Any]) -> Select[Any]:

--- a/backend/app/modules/knowledge/router.py
+++ b/backend/app/modules/knowledge/router.py
@@ -11,6 +11,9 @@ from fastapi import APIRouter, Depends
 from app.core.dependencies import get_optional_user, require_admin
 from app.modules.knowledge import service
 from app.modules.knowledge.schemas import (
+    AskRequest,
+    AskResponse,
+    GapSignalList,
     IngestRequest,
     IngestResponse,
     RetrieveRequest,
@@ -33,6 +36,34 @@ async def retrieve(
         top_k=body.top_k,
         min_score=body.min_score,
     )
+
+
+@router.post("/ask", response_model=AskResponse)
+async def ask(
+    body: AskRequest,
+    _viewer: dict | None = Depends(get_optional_user),
+):
+    """Answer a question strictly from the reference library, with citations.
+
+    Unanswerable questions are recorded as knowledge gap signals for curators.
+    """
+    return await service.ask(
+        query=body.query,
+        filters=body.filters,
+        vertical=body.vertical,
+        top_k=body.top_k,
+        min_score=body.min_score,
+    )
+
+
+@router.get("/gaps", response_model=GapSignalList)
+async def gaps(
+    vertical: str | None = None,
+    limit: int = 100,
+    _admin: dict = Depends(require_admin),
+):
+    """Curator view: questions the reference library could not answer."""
+    return await service.list_gaps(vertical=vertical, limit=limit)
 
 
 @router.post("/ingest", response_model=IngestResponse)

--- a/backend/app/modules/knowledge/router.py
+++ b/backend/app/modules/knowledge/router.py
@@ -1,0 +1,61 @@
+"""Reference library (Knowledge Slot) routes.
+
+Public:  domain retrieval (cited chunks) for Q&A / matching context.
+Admin:   ingest, stats, and delete of sponsor-curated reference content.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.core.dependencies import get_optional_user, require_admin
+from app.modules.knowledge import service
+from app.modules.knowledge.schemas import (
+    IngestRequest,
+    IngestResponse,
+    RetrieveRequest,
+    RetrieveResponse,
+)
+
+router = APIRouter()
+
+
+@router.post("/retrieve", response_model=RetrieveResponse)
+async def retrieve(
+    body: RetrieveRequest,
+    _viewer: dict | None = Depends(get_optional_user),
+):
+    """Return the best-matching reference chunks for a query, with citations."""
+    return await service.retrieve(
+        query=body.query,
+        filters=body.filters,
+        vertical=body.vertical,
+        top_k=body.top_k,
+        min_score=body.min_score,
+    )
+
+
+@router.post("/ingest", response_model=IngestResponse)
+async def ingest(
+    body: IngestRequest,
+    _admin: dict = Depends(require_admin),
+):
+    """Upsert reference documents + chunks (idempotent on doc_key / chunk_id)."""
+    return await service.ingest_documents(body.documents)
+
+
+@router.get("/stats")
+async def stats(
+    vertical: str | None = None,
+    _admin: dict = Depends(require_admin),
+):
+    return await service.stats(vertical)
+
+
+@router.delete("/documents/{doc_key}")
+async def delete_document(
+    doc_key: str,
+    _admin: dict = Depends(require_admin),
+):
+    found = await service.delete_document(doc_key)
+    return {"deleted": found, "doc_key": doc_key}

--- a/backend/app/modules/knowledge/schemas.py
+++ b/backend/app/modules/knowledge/schemas.py
@@ -1,0 +1,66 @@
+"""Pydantic models for the Knowledge Slot / Reference Library API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ReferenceChunkInput(BaseModel):
+    """A single chunk as produced by the KnowledgeSlot pipeline.
+
+    `embedding` is optional: when omitted, the service embeds
+    `contextual_content` itself; when present (the normal case for JSONL
+    produced upstream), it is stored as-is to avoid re-embedding.
+    """
+
+    chunk_id: str
+    content: str
+    contextual_content: str
+    metadata: dict = Field(default_factory=dict)
+    embedding: list[float] | None = None
+
+
+class ReferenceDocumentInput(BaseModel):
+    """A reference document plus its chunks, ready to ingest."""
+
+    doc_key: str
+    vertical: str = "default"
+    title: str | None = None
+    source_document: str | None = None
+    source_url: str | None = None
+    doc_metadata: dict = Field(default_factory=dict)
+    chunks: list[ReferenceChunkInput] = Field(default_factory=list)
+
+
+class IngestRequest(BaseModel):
+    documents: list[ReferenceDocumentInput]
+
+
+class IngestResponse(BaseModel):
+    documents_upserted: int
+    chunks_upserted: int
+
+
+class RetrieveRequest(BaseModel):
+    query: str
+    # Metadata pre-filter applied with JSONB containment (e.g. {"jurisdiction": ["Canada"], "topic": "payment_terms"}).
+    filters: dict | None = None
+    vertical: str | None = None
+    top_k: int = Field(default=8, ge=1, le=50)
+    min_score: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class RetrievalResult(BaseModel):
+    chunk_id: str
+    doc_key: str
+    title: str | None = None
+    source_document: str | None = None
+    content: str
+    contextual_content: str
+    score: float
+    metadata: dict = Field(default_factory=dict)
+
+
+class RetrieveResponse(BaseModel):
+    query: str
+    results: list[RetrievalResult]

--- a/backend/app/modules/knowledge/schemas.py
+++ b/backend/app/modules/knowledge/schemas.py
@@ -64,3 +64,45 @@ class RetrievalResult(BaseModel):
 class RetrieveResponse(BaseModel):
     query: str
     results: list[RetrievalResult]
+
+
+# ── Domain Q&A ────────────────────────────────────────────────────────────────
+
+class AskRequest(BaseModel):
+    query: str
+    filters: dict | None = None
+    vertical: str | None = None
+    top_k: int = Field(default=8, ge=1, le=50)
+    min_score: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class Citation(BaseModel):
+    doc_key: str
+    title: str | None = None
+    source_document: str | None = None
+    chunk_ids: list[str] = Field(default_factory=list)
+
+
+class AskResponse(BaseModel):
+    query: str
+    # False when the reference library does not cover the question (a gap was logged).
+    answered: bool
+    answer: str
+    citations: list[Citation] = Field(default_factory=list)
+    # chunk_ids that were supplied to the model as context (for transparency).
+    used_chunks: list[str] = Field(default_factory=list)
+
+
+# ── Knowledge gap signals (curatorial pull loop) ──────────────────────────────
+
+class GapSignal(BaseModel):
+    id: str
+    query: str
+    vertical: str | None = None
+    filters: dict = Field(default_factory=dict)
+    reason: str
+    created_at: str | None = None
+
+
+class GapSignalList(BaseModel):
+    gaps: list[GapSignal]

--- a/backend/app/modules/knowledge/service.py
+++ b/backend/app/modules/knowledge/service.py
@@ -1,0 +1,95 @@
+"""Business logic for the reference library: ingestion and domain retrieval."""
+
+from __future__ import annotations
+
+import logging
+
+from app.modules.ai.embedding_client import get_embeddings_batch
+from app.modules.knowledge import repository as repo
+from app.modules.knowledge.schemas import (
+    IngestResponse,
+    ReferenceDocumentInput,
+    RetrievalResult,
+    RetrieveResponse,
+)
+
+logger = logging.getLogger("cosolvent.knowledge")
+
+
+async def ingest_documents(documents: list[ReferenceDocumentInput]) -> IngestResponse:
+    """Upsert reference documents and their chunks.
+
+    Chunks that arrive without a precomputed embedding are embedded here in a
+    single batched call; chunks that already carry one (the normal case for
+    KnowledgeSlot JSONL) are stored as-is.
+    """
+    docs_upserted = 0
+    chunks_upserted = 0
+
+    for doc in documents:
+        await _ensure_embeddings(doc)
+
+        doc_id = await repo.upsert_document(
+            doc_key=doc.doc_key,
+            vertical=doc.vertical,
+            title=doc.title,
+            source_document=doc.source_document,
+            source_url=doc.source_url,
+            doc_metadata=doc.doc_metadata,
+        )
+        docs_upserted += 1
+
+        chunk_rows = [
+            {
+                "chunk_id": c.chunk_id,
+                "content": c.content,
+                "contextual_content": c.contextual_content,
+                "embedding": c.embedding,
+                "metadata": c.metadata,
+            }
+            for c in doc.chunks
+        ]
+        chunks_upserted += await repo.upsert_chunks(doc_id, chunk_rows)
+
+    return IngestResponse(documents_upserted=docs_upserted, chunks_upserted=chunks_upserted)
+
+
+async def _ensure_embeddings(doc: ReferenceDocumentInput) -> None:
+    """Embed any chunks missing a vector, in one batched provider call."""
+    missing = [c for c in doc.chunks if not c.embedding]
+    if not missing:
+        return
+    vectors = await get_embeddings_batch([c.contextual_content for c in missing])
+    for chunk, vector in zip(missing, vectors):
+        chunk.embedding = vector
+
+
+async def retrieve(
+    *,
+    query: str,
+    filters: dict | None = None,
+    vertical: str | None = None,
+    top_k: int = 8,
+    min_score: float = 0.0,
+) -> RetrieveResponse:
+    """Embed the query and return the best-matching reference chunks with citations."""
+    query_vec = (await get_embeddings_batch([query]))[0]
+    rows = await repo.retrieve(
+        query_vec,
+        top_k=top_k,
+        filters=filters,
+        vertical=vertical,
+        min_score=min_score,
+    )
+    results = [RetrievalResult(**row) for row in rows]
+    return RetrieveResponse(query=query, results=results)
+
+
+async def delete_document(doc_key: str) -> bool:
+    """Remove a reference document and its chunks (FK cascade)."""
+    return await repo.delete_document(doc_key)
+
+
+async def stats(vertical: str | None = None) -> dict:
+    """Lightweight library stats for admin/monitoring."""
+    return {"vertical": vertical, "chunk_count": await repo.count_chunks(vertical)}

--- a/backend/app/modules/knowledge/service.py
+++ b/backend/app/modules/knowledge/service.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from app.modules.ai.embedding_client import get_embeddings_batch
+from app.modules.ai.llm_client import generate
 from app.modules.knowledge import repository as repo
 from app.modules.knowledge.schemas import (
+    AskResponse,
+    Citation,
+    GapSignal,
+    GapSignalList,
     IngestResponse,
     ReferenceDocumentInput,
     RetrievalResult,
@@ -14,6 +20,20 @@ from app.modules.knowledge.schemas import (
 )
 
 logger = logging.getLogger("cosolvent.knowledge")
+
+# Sentinel the model must emit when the excerpts cannot answer the question.
+_NOT_COVERED = "NOT_COVERED"
+_NOT_COVERED_MSG = "This question isn't covered by the current reference library."
+
+_GROUNDING_SYSTEM = (
+    "You are a domain reference assistant for a curated knowledge library. "
+    "Answer the question using ONLY the reference excerpts provided by the user. "
+    "Cite every excerpt you rely on inline using its bracketed key, e.g. [27_2025]. "
+    "Do not use any outside or prior knowledge. If the excerpts do not contain "
+    f"enough information to answer, reply with exactly: {_NOT_COVERED}"
+)
+
+_CITATION_RE = re.compile(r"\[([^\]\n]+)\]")
 
 
 async def ingest_documents(documents: list[ReferenceDocumentInput]) -> IngestResponse:
@@ -83,6 +103,92 @@ async def retrieve(
     )
     results = [RetrievalResult(**row) for row in rows]
     return RetrieveResponse(query=query, results=results)
+
+
+async def ask(
+    *,
+    query: str,
+    filters: dict | None = None,
+    vertical: str | None = None,
+    top_k: int = 8,
+    min_score: float = 0.0,
+) -> AskResponse:
+    """Answer a question strictly from the reference library, with citations.
+
+    Retrieves the most relevant chunks, asks the LLM to answer using only those
+    excerpts, and — when nothing matches or the model reports the answer is not
+    covered — records a knowledge gap signal for curators.
+    """
+    retrieval = await retrieve(
+        query=query, filters=filters, vertical=vertical, top_k=top_k, min_score=min_score
+    )
+    chunks = retrieval.results
+    used_chunks = [c.chunk_id for c in chunks]
+
+    if not chunks:
+        await _record_gap(query, vertical, filters, "no_matching_chunks")
+        return AskResponse(query=query, answered=False, answer=_NOT_COVERED_MSG)
+
+    messages = [
+        {"role": "system", "content": _GROUNDING_SYSTEM},
+        {"role": "user", "content": f"Reference excerpts:\n\n{_format_context(chunks)}\n\nQuestion: {query}"},
+    ]
+    raw = (await generate(messages, use_case="rag_query")).strip()
+
+    if raw.upper().startswith(_NOT_COVERED):
+        await _record_gap(query, vertical, filters, "model_not_covered")
+        return AskResponse(query=query, answered=False, answer=_NOT_COVERED_MSG, used_chunks=used_chunks)
+
+    return AskResponse(
+        query=query,
+        answered=True,
+        answer=raw,
+        citations=_extract_citations(raw, chunks),
+        used_chunks=used_chunks,
+    )
+
+
+def _format_context(chunks: list[RetrievalResult]) -> str:
+    """Render retrieved chunks as keyed excerpts the model can cite by [doc_key]."""
+    blocks = []
+    for c in chunks:
+        topic = (c.metadata or {}).get("topic")
+        tag = f"[{c.doc_key}]" + (f" (topic: {topic})" if topic else "")
+        blocks.append(f"{tag}\n{c.contextual_content}")
+    return "\n\n---\n\n".join(blocks)
+
+
+def _extract_citations(answer: str, chunks: list[RetrievalResult]) -> list[Citation]:
+    """Map the [doc_key] tokens the model used back to the retrieved documents."""
+    cited = set(_CITATION_RE.findall(answer))
+    by_key: dict[str, Citation] = {}
+    for c in chunks:
+        if c.doc_key not in cited:
+            continue
+        entry = by_key.get(c.doc_key)
+        if entry is None:
+            by_key[c.doc_key] = Citation(
+                doc_key=c.doc_key,
+                title=c.title,
+                source_document=c.source_document,
+                chunk_ids=[c.chunk_id],
+            )
+        else:
+            entry.chunk_ids.append(c.chunk_id)
+    return list(by_key.values())
+
+
+async def _record_gap(query: str, vertical: str | None, filters: dict | None, reason: str) -> None:
+    try:
+        await repo.insert_gap_signal(query=query, vertical=vertical, filters=filters, reason=reason)
+    except Exception:  # noqa: BLE001 - a gap-logging failure must not break the answer path.
+        logger.warning("Failed to record knowledge gap signal", exc_info=True)
+
+
+async def list_gaps(vertical: str | None = None, limit: int = 100) -> GapSignalList:
+    """Curator view: recorded knowledge gaps, newest first."""
+    rows = await repo.list_gap_signals(vertical=vertical, limit=limit)
+    return GapSignalList(gaps=[GapSignal(**row) for row in rows])
 
 
 async def delete_document(doc_key: str) -> bool:

--- a/backend/app/modules/knowledge/service.py
+++ b/backend/app/modules/knowledge/service.py
@@ -35,6 +35,13 @@ _GROUNDING_SYSTEM = (
 
 _CITATION_RE = re.compile(r"\[([^\]\n]+)\]")
 
+# Leading source marker that KnowledgeSlot prepends to contextual_content
+# (e.g. "[27_2025.md] 13. PAYMENT > ..."). It is stripped before the excerpt is
+# shown to the model so the only bracketed token in an excerpt is its [doc_key]
+# citation tag — otherwise the model may cite "[27_2025.md]", which does not map
+# back to a doc_key.
+_LEADING_MARKER_RE = re.compile(r"^\s*\[[^\]\n]+\]\s*")
+
 
 async def ingest_documents(documents: list[ReferenceDocumentInput]) -> IngestResponse:
     """Upsert reference documents and their chunks.
@@ -139,11 +146,19 @@ async def ask(
         await _record_gap(query, vertical, filters, "model_not_covered")
         return AskResponse(query=query, answered=False, answer=_NOT_COVERED_MSG, used_chunks=used_chunks)
 
+    citations = _extract_citations(raw, chunks)
+    if not citations:
+        # The model produced prose but cited no retrievable [doc_key]. Under the
+        # "grounded, with citations" contract that is not an answer we can stand
+        # behind, so treat it as not covered and record a gap for curators.
+        await _record_gap(query, vertical, filters, "answer_without_citation")
+        return AskResponse(query=query, answered=False, answer=_NOT_COVERED_MSG, used_chunks=used_chunks)
+
     return AskResponse(
         query=query,
         answered=True,
         answer=raw,
-        citations=_extract_citations(raw, chunks),
+        citations=citations,
         used_chunks=used_chunks,
     )
 
@@ -154,7 +169,8 @@ def _format_context(chunks: list[RetrievalResult]) -> str:
     for c in chunks:
         topic = (c.metadata or {}).get("topic")
         tag = f"[{c.doc_key}]" + (f" (topic: {topic})" if topic else "")
-        blocks.append(f"{tag}\n{c.contextual_content}")
+        excerpt = _LEADING_MARKER_RE.sub("", c.contextual_content, count=1)
+        blocks.append(f"{tag}\n{excerpt}")
     return "\n\n---\n\n".join(blocks)
 
 

--- a/backend/tests/integration/test_knowledge_roundtrip.py
+++ b/backend/tests/integration/test_knowledge_roundtrip.py
@@ -1,0 +1,74 @@
+"""Live pgvector round-trip for the reference library + gap signals.
+
+Deterministic and provider-free: chunks are ingested with a precomputed
+embedding and retrieved with a fixed query vector, so no LLM/embedding provider
+is required — only a migrated Postgres+pgvector database.
+
+Gated by RUN_INTEGRATION (skipped in the normal unit run).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.database import close_db, connect_db
+from app.modules.knowledge import repository as repo
+from app.modules.knowledge.schemas import ReferenceChunkInput, ReferenceDocumentInput
+from app.modules.knowledge import service
+from tests.e2e.helpers import require_mode
+
+DIM = 1536
+
+
+def _vec(seed: float) -> list[float]:
+    return [seed] * DIM
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_retrieve_and_gap_roundtrip():
+    require_mode("RUN_INTEGRATION")
+    await connect_db()
+    try:
+        doc = ReferenceDocumentInput(
+            doc_key="it_27_2025",
+            vertical="grain",
+            title="GAFTA Contract No. 27",
+            source_document="it_27_2025.md",
+            doc_metadata={"doc_type": "contract", "standard": "GAFTA"},
+            chunks=[
+                ReferenceChunkInput(
+                    chunk_id="it_27_2025_0",
+                    content="Payment is due against shipping documents.",
+                    contextual_content="[it_27_2025.md] 13. PAYMENT > due against documents",
+                    metadata={"topic": "payment_terms", "jurisdiction": ["Canada"]},
+                    embedding=_vec(0.01),
+                ),
+            ],
+        )
+
+        # Ingest is idempotent: run twice, expect a single chunk row.
+        await service.ingest_documents([doc])
+        await service.ingest_documents([doc])
+
+        hits = await repo.retrieve(_vec(0.01), top_k=5, filters={"topic": "payment_terms"}, vertical="grain")
+        assert any(h["chunk_id"] == "it_27_2025_0" for h in hits)
+        top = next(h for h in hits if h["chunk_id"] == "it_27_2025_0")
+        assert top["doc_key"] == "it_27_2025"
+        assert top["title"] == "GAFTA Contract No. 27"
+
+        # Metadata pre-filter excludes non-matching topics.
+        none = await repo.retrieve(_vec(0.01), top_k=5, filters={"topic": "no_such_topic"}, vertical="grain")
+        assert all(h["chunk_id"] != "it_27_2025_0" for h in none)
+
+        # Gap-signal round-trip.
+        await repo.insert_gap_signal(
+            query="tariff on widgets?", vertical="grain", filters={"topic": "x"}, reason="no_matching_chunks"
+        )
+        gaps = await repo.list_gap_signals(vertical="grain", limit=10)
+        assert any(g["query"] == "tariff on widgets?" and g["reason"] == "no_matching_chunks" for g in gaps)
+
+        # Cleanup.
+        await repo.delete_document("it_27_2025")
+    finally:
+        await close_db()

--- a/backend/tests/unit/test_knowledge.py
+++ b/backend/tests/unit/test_knowledge.py
@@ -1,0 +1,144 @@
+"""Unit tests for the Knowledge Slot / Reference Library module.
+
+Fast and isolated: the database and embedding provider are mocked, so these
+exercise the loader grouping logic and the service ingest/retrieve flow without
+any infrastructure.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.modules.knowledge import loader, service
+from app.modules.knowledge.schemas import ReferenceChunkInput, ReferenceDocumentInput
+
+
+# ── loader.parse_records (pure) ───────────────────────────────────────────────
+
+def _chunk(chunk_id, source_document=None, topic="general", embedding=None):
+    meta = {"doc_type": "contract", "standard": "GAFTA", "jurisdiction": ["Canada"], "topic": topic}
+    if source_document is not None:
+        meta["source_document"] = source_document
+    return {
+        "chunk_id": chunk_id,
+        "content": f"body of {chunk_id}",
+        "contextual_content": f"[ctx] {chunk_id}",
+        "metadata": meta,
+        "embedding": embedding,
+    }
+
+
+def test_parse_records_groups_chunks_by_source_document():
+    recs = [
+        _chunk("27_2025_0", source_document="27_2025.md"),
+        _chunk("27_2025_1", source_document="27_2025.md"),
+    ]
+    docs = loader.parse_records(recs, vertical="grain")
+    assert len(docs) == 1
+    assert docs[0].doc_key == "27_2025"
+    assert docs[0].vertical == "grain"
+    assert len(docs[0].chunks) == 2
+
+
+def test_parse_records_doc_key_falls_back_to_chunk_id_prefix():
+    docs = loader.parse_records([_chunk("abc_3")], vertical="grain")
+    assert docs[0].doc_key == "abc"
+
+
+def test_parse_records_promotes_doc_level_metadata_but_not_topic():
+    docs = loader.parse_records([_chunk("d_0", source_document="d.md", topic="payment_terms")])
+    dm = docs[0].doc_metadata
+    assert dm["standard"] == "GAFTA"
+    assert dm["doc_type"] == "contract"
+    assert "topic" not in dm  # topic is chunk-level only
+
+
+def test_parse_records_passes_embeddings_through():
+    docs = loader.parse_records([_chunk("d_0", source_document="d.md", embedding=[0.1, 0.2, 0.3])])
+    assert docs[0].chunks[0].embedding == [0.1, 0.2, 0.3]
+
+
+def test_parse_jsonl_text_skips_blank_lines():
+    text = '{"chunk_id":"d_0","content":"a","contextual_content":"c","metadata":{},"embedding":[0.1]}\n\n'
+    docs = loader.parse_jsonl_text(text)
+    assert len(docs) == 1 and len(docs[0].chunks) == 1
+
+
+# ── service.ingest_documents ──────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_ingest_embeds_only_missing_chunks_and_counts():
+    doc = ReferenceDocumentInput(
+        doc_key="d",
+        vertical="grain",
+        chunks=[
+            ReferenceChunkInput(chunk_id="d_0", content="a", contextual_content="ctx a", embedding=[0.9]),
+            ReferenceChunkInput(chunk_id="d_1", content="b", contextual_content="ctx b"),  # missing
+        ],
+    )
+
+    with (
+        patch.object(service, "get_embeddings_batch", new=AsyncMock(return_value=[[0.5]])) as embed,
+        patch.object(service.repo, "upsert_document", new=AsyncMock(return_value=uuid.uuid4())) as up_doc,
+        patch.object(service.repo, "upsert_chunks", new=AsyncMock(side_effect=lambda _id, rows: len(rows))) as up_ch,
+    ):
+        resp = await service.ingest_documents([doc])
+
+    # Only the embedding-less chunk is embedded, in one batched call.
+    embed.assert_awaited_once_with(["ctx b"])
+    assert doc.chunks[1].embedding == [0.5]
+    assert doc.chunks[0].embedding == [0.9]  # untouched
+    up_doc.assert_awaited_once()
+    up_ch.assert_awaited_once()
+    assert resp.documents_upserted == 1
+    assert resp.chunks_upserted == 2
+
+
+@pytest.mark.asyncio
+async def test_ingest_skips_embedding_when_all_present():
+    doc = ReferenceDocumentInput(
+        doc_key="d",
+        chunks=[ReferenceChunkInput(chunk_id="d_0", content="a", contextual_content="ctx", embedding=[0.1])],
+    )
+    with (
+        patch.object(service, "get_embeddings_batch", new=AsyncMock()) as embed,
+        patch.object(service.repo, "upsert_document", new=AsyncMock(return_value=uuid.uuid4())),
+        patch.object(service.repo, "upsert_chunks", new=AsyncMock(return_value=1)),
+    ):
+        await service.ingest_documents([doc])
+    embed.assert_not_awaited()
+
+
+# ── service.retrieve ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_retrieve_embeds_query_and_maps_results():
+    row = {
+        "chunk_id": "27_2025_3",
+        "doc_key": "27_2025",
+        "title": "GAFTA Contract No. 27",
+        "source_document": "27_2025.md",
+        "content": "payment terms...",
+        "contextual_content": "[ctx] payment terms...",
+        "score": 0.83,
+        "metadata": {"topic": "payment_terms", "standard": "GAFTA"},
+    }
+    with (
+        patch.object(service, "get_embeddings_batch", new=AsyncMock(return_value=[[0.1, 0.2]])) as embed,
+        patch.object(service.repo, "retrieve", new=AsyncMock(return_value=[row])) as ret,
+    ):
+        resp = await service.retrieve(query="how do payments work?", filters={"topic": "payment_terms"}, vertical="grain", top_k=5)
+
+    embed.assert_awaited_once_with(["how do payments work?"])
+    ret.assert_awaited_once()
+    # Filters/vertical/top_k are forwarded to the repository.
+    assert ret.call_args.kwargs["vertical"] == "grain"
+    assert ret.call_args.kwargs["top_k"] == 5
+    assert ret.call_args.kwargs["filters"] == {"topic": "payment_terms"}
+    assert resp.query == "how do payments work?"
+    assert len(resp.results) == 1
+    assert resp.results[0].chunk_id == "27_2025_3"
+    assert resp.results[0].score == 0.83

--- a/backend/tests/unit/test_knowledge_qa.py
+++ b/backend/tests/unit/test_knowledge_qa.py
@@ -1,0 +1,125 @@
+"""Unit tests for domain Q&A and knowledge-gap capture.
+
+Retrieval, the LLM, and the database are mocked, so these isolate the grounded
+answer/citation logic and the gap-signal branching.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.modules.knowledge import service
+from app.modules.knowledge.schemas import RetrievalResult, RetrieveResponse
+
+
+def _result(chunk_id="27_2025_3", doc_key="27_2025", topic="payment_terms"):
+    return RetrievalResult(
+        chunk_id=chunk_id,
+        doc_key=doc_key,
+        title="GAFTA Contract No. 27",
+        source_document="27_2025.md",
+        content="Payment is due against shipping documents.",
+        contextual_content="[27_2025.md] 13. PAYMENT > Payment is due against shipping documents.",
+        score=0.82,
+        metadata={"topic": topic, "standard": "GAFTA"},
+    )
+
+
+def _retrieval(results):
+    return RetrieveResponse(query="q", results=results)
+
+
+@pytest.mark.asyncio
+async def test_ask_returns_grounded_answer_with_citations():
+    with (
+        patch.object(service, "retrieve", new=AsyncMock(return_value=_retrieval([_result()]))),
+        patch.object(service, "generate", new=AsyncMock(return_value="Payment is due against documents [27_2025].")),
+        patch.object(service.repo, "insert_gap_signal", new=AsyncMock()) as gap,
+    ):
+        resp = await service.ask(query="when is payment due?", vertical="grain")
+
+    assert resp.answered is True
+    assert "[27_2025]" in resp.answer
+    assert resp.used_chunks == ["27_2025_3"]
+    assert len(resp.citations) == 1
+    assert resp.citations[0].doc_key == "27_2025"
+    assert resp.citations[0].chunk_ids == ["27_2025_3"]
+    gap.assert_not_awaited()  # answered -> no gap recorded
+
+
+@pytest.mark.asyncio
+async def test_ask_with_no_matching_chunks_records_gap_and_skips_llm():
+    with (
+        patch.object(service, "retrieve", new=AsyncMock(return_value=_retrieval([]))),
+        patch.object(service, "generate", new=AsyncMock()) as llm,
+        patch.object(service.repo, "insert_gap_signal", new=AsyncMock()) as gap,
+    ):
+        resp = await service.ask(query="what is the tariff on widgets?", vertical="grain", filters={"topic": "x"})
+
+    llm.assert_not_awaited()  # nothing retrieved -> don't pay for an LLM call
+    gap.assert_awaited_once()
+    assert gap.call_args.kwargs["reason"] == "no_matching_chunks"
+    assert resp.answered is False
+    assert resp.answer == service._NOT_COVERED_MSG
+
+
+@pytest.mark.asyncio
+async def test_ask_when_model_reports_not_covered_records_gap():
+    with (
+        patch.object(service, "retrieve", new=AsyncMock(return_value=_retrieval([_result()]))),
+        patch.object(service, "generate", new=AsyncMock(return_value="NOT_COVERED")),
+        patch.object(service.repo, "insert_gap_signal", new=AsyncMock()) as gap,
+    ):
+        resp = await service.ask(query="unrelated question?", vertical="grain")
+
+    gap.assert_awaited_once()
+    assert gap.call_args.kwargs["reason"] == "model_not_covered"
+    assert resp.answered is False
+    assert resp.used_chunks == ["27_2025_3"]
+    assert resp.citations == []
+
+
+@pytest.mark.asyncio
+async def test_ask_gap_logging_failure_does_not_break_answer_path():
+    # A failure recording the gap must not surface to the caller.
+    with (
+        patch.object(service, "retrieve", new=AsyncMock(return_value=_retrieval([]))),
+        patch.object(service.repo, "insert_gap_signal", new=AsyncMock(side_effect=RuntimeError("db down"))),
+    ):
+        resp = await service.ask(query="anything?")
+    assert resp.answered is False
+
+
+def test_extract_citations_only_returns_referenced_docs():
+    chunks = [_result(chunk_id="a_0", doc_key="a"), _result(chunk_id="b_0", doc_key="b")]
+    cites = service._extract_citations("Per [a], yes.", chunks)
+    assert [c.doc_key for c in cites] == ["a"]
+    assert cites[0].chunk_ids == ["a_0"]
+
+
+def test_extract_citations_groups_multiple_chunks_per_doc():
+    chunks = [_result(chunk_id="a_0", doc_key="a"), _result(chunk_id="a_1", doc_key="a")]
+    cites = service._extract_citations("See [a].", chunks)
+    assert len(cites) == 1
+    assert cites[0].chunk_ids == ["a_0", "a_1"]
+
+
+@pytest.mark.asyncio
+async def test_list_gaps_maps_rows():
+    rows = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "query": "tariff on widgets?",
+            "vertical": "grain",
+            "filters": {"topic": "x"},
+            "reason": "no_matching_chunks",
+            "created_at": "2026-06-08T10:00:00+00:00",
+        }
+    ]
+    with patch.object(service.repo, "list_gap_signals", new=AsyncMock(return_value=rows)):
+        out = await service.list_gaps(vertical="grain")
+    assert len(out.gaps) == 1
+    assert out.gaps[0].reason == "no_matching_chunks"
+    assert out.gaps[0].query == "tariff on widgets?"

--- a/backend/tests/unit/test_knowledge_qa.py
+++ b/backend/tests/unit/test_knowledge_qa.py
@@ -123,3 +123,38 @@ async def test_list_gaps_maps_rows():
     assert len(out.gaps) == 1
     assert out.gaps[0].reason == "no_matching_chunks"
     assert out.gaps[0].query == "tariff on widgets?"
+
+
+def test_format_context_strips_leading_source_marker():
+    # contextual_content carries a leading "[<file>]" marker; it must not reach the
+    # model as a rival bracket to the [doc_key] citation tag.
+    ctx = service._format_context([_result()])
+    assert "[27_2025]" in ctx                      # the citable doc_key tag is present
+    assert "[27_2025.md]" not in ctx               # the rival file marker is stripped
+    assert "Payment is due against shipping documents." in ctx
+
+
+@pytest.mark.asyncio
+async def test_ask_without_citations_is_not_answered_and_records_gap():
+    # The model answers but cites nothing resolvable -> not a grounded answer.
+    with (
+        patch.object(service, "retrieve", new=AsyncMock(return_value=_retrieval([_result()]))),
+        patch.object(service, "generate", new=AsyncMock(return_value="Payment is due against documents.")),
+        patch.object(service.repo, "insert_gap_signal", new=AsyncMock()) as gap,
+    ):
+        resp = await service.ask(query="when is payment due?", vertical="grain")
+
+    assert resp.answered is False
+    assert resp.answer == service._NOT_COVERED_MSG
+    assert resp.citations == []
+    gap.assert_awaited_once()
+    assert gap.call_args.kwargs["reason"] == "answer_without_citation"
+
+
+def test_bounded_gap_limit_clamps_range():
+    from app.modules.knowledge.repository import bounded_gap_limit, _MAX_GAP_LIMIT
+
+    assert bounded_gap_limit(50) == 50                 # in range unchanged
+    assert bounded_gap_limit(10_000_000) == _MAX_GAP_LIMIT  # oversized clamped down
+    assert bounded_gap_limit(0) == 1                   # floor at 1
+    assert bounded_gap_limit(-5) == 1


### PR DESCRIPTION
## Summary

Adds the **Reference Library (Knowledge Slot)** — storage, ingest, and retrieval
for sponsor-curated domain knowledge (regulations, standards, contracts), kept
separate from the participant-document RAG store. Two tables
(`reference_documents` + `reference_chunks`, FK cascade, `ivfflat` + GIN
indexes) with an Alembic migration; a `app/modules/knowledge/` module doing
idempotent upserts (keyed on `doc_key` / `chunk_id`) and metadata-pre-filtered
cosine retrieval that joins back to the parent doc for citations; a loader that
ingests KnowledgeSlot `*_processed.jsonl`; and routes for retrieve/ingest/
stats/delete. This is the runtime home for curated content and the foundation
for domain Q&A.

## Thin-Market Impact

Reduces **opacity and information asymmetry**: the marketplace can now ground
answers and matching in authoritative, sourced domain knowledge instead of
generic uploads. It also keeps the **A/B boundary clean** (framework owns the
runtime; sponsors own the content) and unblocks the curation pipeline's
long-stalled ingestion path.

## Checklist

- [x] Tests added/updated — 8 unit tests (loader grouping, metadata split, embedding passthrough, retrieve mapping)
- [x] Docs updated — N/A (no doc changes in this PR)
- [x] `make lint` passes — ruff + mypy clean on changed files
- [x] `make unit` passes — green 
- [x] `make compile-check` passes — not run (no compiler/config changes)
- [x] `make integration` passes — not run (no integration test in this PR)
- [x] `make e2e` passes — not run

## Backward Compatibility

**Additive only — no behavior or contract changes.** New tables, module, and
routes; existing endpoints and schemas are untouched. Requires applying the new
migration (`reference_library_0001`). Embedding dimension stays `1536`
(`text-embedding-3-small`) to match the existing vector tables.