### PR TITLE
Cited domain qa

### DIFF
--- a/backend/alembic/versions/knowledge_gap_signals_0001.py
+++ b/backend/alembic/versions/knowledge_gap_signals_0001.py
@@ -1,0 +1,42 @@
+"""Knowledge gap signals (curatorial pull loop).
+
+Records questions the reference library could not answer, so curators know what
+authoritative content is missing. Written by the domain-Q&A path.
+
+Revision ID: knowledge_gap_signals_0001
+Revises: reference_library_0001
+Create Date: 2026-06-08
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "knowledge_gap_signals_0001"
+down_revision = "reference_library_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "knowledge_gap_signals",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("query", sa.Text(), nullable=False),
+        sa.Column("vertical", sa.Text(), nullable=True),
+        sa.Column("filters", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_knowledge_gap_signals_created_at "
+        "ON knowledge_gap_signals (created_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_knowledge_gap_signals_created_at", table_name="knowledge_gap_signals")
+    op.drop_table("knowledge_gap_signals")

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -618,6 +618,13 @@ async def _ensure_indexes(conn) -> None:
             "ON reference_chunks USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)"
         )
     )
+    # Knowledge gap signals: curators read newest-first.
+    await conn.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_knowledge_gap_signals_created_at "
+            "ON knowledge_gap_signals (created_at DESC)"
+        )
+    )
 
     # Cleanup stale vector rows before enforcing referential integrity.
     await conn.execute(

--- a/backend/app/core/db_schema.py
+++ b/backend/app/core/db_schema.py
@@ -133,6 +133,21 @@ reference_chunks = Table(
     Column("updated_at", DateTime(timezone=True), nullable=False, server_default=text("NOW()")),
 )
 
+# Knowledge gap signals: questions the reference library could not answer.
+# The curatorial "pull signal" — tells curators what authoritative content is
+# missing. Written from the domain-Q&A path; read by curators via the admin API.
+knowledge_gap_signals = Table(
+    "knowledge_gap_signals",
+    metadata,
+    Column("id", UUID(as_uuid=True), primary_key=True, default=uuid.uuid4),
+    Column("query", Text, nullable=False),
+    Column("vertical", Text, nullable=True),
+    Column("filters", JSONB, nullable=False, server_default=text("'{}'::jsonb")),
+    # Why the gap was recorded: "no_matching_chunks" | "model_not_covered".
+    Column("reason", Text, nullable=False),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=text("NOW()")),
+)
+
 
 def table_for_collection(name: str) -> Table:
     table = DOC_TABLES.get(name)

--- a/backend/app/modules/knowledge/repository.py
+++ b/backend/app/modules/knowledge/repository.py
@@ -210,6 +210,16 @@ async def insert_gap_signal(
     return str(gap_id)
 
 
+# Upper bound on how many gap rows a single query may request, so an arbitrary
+# caller-supplied `limit` on the admin endpoint can't trigger an oversized read.
+_MAX_GAP_LIMIT = 500
+
+
+def bounded_gap_limit(limit: int) -> int:
+    """Clamp a requested gap-list limit into [1, _MAX_GAP_LIMIT]."""
+    return max(1, min(limit, _MAX_GAP_LIMIT))
+
+
 async def list_gap_signals(*, vertical: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
     """Newest-first list of recorded knowledge gaps (curator view)."""
     stmt: Select[Any] = select(knowledge_gap_signals).order_by(
@@ -217,7 +227,7 @@ async def list_gap_signals(*, vertical: str | None = None, limit: int = 100) -> 
     )
     if vertical:
         stmt = stmt.where(knowledge_gap_signals.c.vertical == vertical)
-    stmt = stmt.limit(max(1, limit))
+    stmt = stmt.limit(bounded_gap_limit(limit))
 
     async with session_scope() as session:
         rows = (await session.execute(stmt)).all()

--- a/backend/app/modules/knowledge/repository.py
+++ b/backend/app/modules/knowledge/repository.py
@@ -9,14 +9,14 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy import Select, delete, false, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.sql import func
 
 from app.core.database import session_scope
-from app.core.db_schema import reference_chunks, reference_documents
+from app.core.db_schema import knowledge_gap_signals, reference_chunks, reference_documents
 
 logger = logging.getLogger("cosolvent.knowledge")
 
@@ -165,7 +165,9 @@ async def delete_document(doc_key: str) -> bool:
             delete(reference_documents).where(reference_documents.c.doc_key == doc_key)
         )
         await session.commit()
-    return (result.rowcount or 0) > 0
+    # rowcount lives on the underlying CursorResult; the Result[Any] type hint
+    # doesn't expose it, so read it dynamically.
+    return (cast(Any, result).rowcount or 0) > 0
 
 
 async def count_chunks(vertical: str | None = None) -> int:
@@ -183,6 +185,54 @@ async def count_chunks(vertical: str | None = None) -> int:
         )
     async with session_scope() as session:
         return int((await session.execute(stmt)).scalar_one())
+
+
+async def insert_gap_signal(
+    *,
+    query: str,
+    vertical: str | None,
+    filters: dict[str, Any] | None,
+    reason: str,
+) -> str:
+    """Record a knowledge gap (question the library could not answer). Returns its id."""
+    gap_id = uuid.uuid4()
+    async with session_scope() as session:
+        await session.execute(
+            knowledge_gap_signals.insert().values(
+                id=gap_id,
+                query=query,
+                vertical=vertical,
+                filters=filters or {},
+                reason=reason,
+            )
+        )
+        await session.commit()
+    return str(gap_id)
+
+
+async def list_gap_signals(*, vertical: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    """Newest-first list of recorded knowledge gaps (curator view)."""
+    stmt: Select[Any] = select(knowledge_gap_signals).order_by(
+        knowledge_gap_signals.c.created_at.desc()
+    )
+    if vertical:
+        stmt = stmt.where(knowledge_gap_signals.c.vertical == vertical)
+    stmt = stmt.limit(max(1, limit))
+
+    async with session_scope() as session:
+        rows = (await session.execute(stmt)).all()
+
+    return [
+        {
+            "id": str(row.id),
+            "query": row.query,
+            "vertical": row.vertical,
+            "filters": row.filters or {},
+            "reason": row.reason,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
+        }
+        for row in rows
+    ]
 
 
 def _apply_metadata_filters(stmt: Select[Any], metadata_column: Any, filters: dict[str, Any]) -> Select[Any]:

--- a/backend/app/modules/knowledge/router.py
+++ b/backend/app/modules/knowledge/router.py
@@ -11,6 +11,9 @@ from fastapi import APIRouter, Depends
 from app.core.dependencies import get_optional_user, require_admin
 from app.modules.knowledge import service
 from app.modules.knowledge.schemas import (
+    AskRequest,
+    AskResponse,
+    GapSignalList,
     IngestRequest,
     IngestResponse,
     RetrieveRequest,
@@ -33,6 +36,34 @@ async def retrieve(
         top_k=body.top_k,
         min_score=body.min_score,
     )
+
+
+@router.post("/ask", response_model=AskResponse)
+async def ask(
+    body: AskRequest,
+    _viewer: dict | None = Depends(get_optional_user),
+):
+    """Answer a question strictly from the reference library, with citations.
+
+    Unanswerable questions are recorded as knowledge gap signals for curators.
+    """
+    return await service.ask(
+        query=body.query,
+        filters=body.filters,
+        vertical=body.vertical,
+        top_k=body.top_k,
+        min_score=body.min_score,
+    )
+
+
+@router.get("/gaps", response_model=GapSignalList)
+async def gaps(
+    vertical: str | None = None,
+    limit: int = 100,
+    _admin: dict = Depends(require_admin),
+):
+    """Curator view: questions the reference library could not answer."""
+    return await service.list_gaps(vertical=vertical, limit=limit)
 
 
 @router.post("/ingest", response_model=IngestResponse)

--- a/backend/app/modules/knowledge/schemas.py
+++ b/backend/app/modules/knowledge/schemas.py
@@ -64,3 +64,45 @@ class RetrievalResult(BaseModel):
 class RetrieveResponse(BaseModel):
     query: str
     results: list[RetrievalResult]
+
+
+# ── Domain Q&A ────────────────────────────────────────────────────────────────
+
+class AskRequest(BaseModel):
+    query: str
+    filters: dict | None = None
+    vertical: str | None = None
+    top_k: int = Field(default=8, ge=1, le=50)
+    min_score: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class Citation(BaseModel):
+    doc_key: str
+    title: str | None = None
+    source_document: str | None = None
+    chunk_ids: list[str] = Field(default_factory=list)
+
+
+class AskResponse(BaseModel):
+    query: str
+    # False when the reference library does not cover the question (a gap was logged).
+    answered: bool
+    answer: str
+    citations: list[Citation] = Field(default_factory=list)
+    # chunk_ids that were supplied to the model as context (for transparency).
+    used_chunks: list[str] = Field(default_factory=list)
+
+
+# ── Knowledge gap signals (curatorial pull loop) ──────────────────────────────
+
+class GapSignal(BaseModel):
+    id: str
+    query: str
+    vertical: str | None = None
+    filters: dict = Field(default_factory=dict)
+    reason: str
+    created_at: str | None = None
+
+
+class GapSignalList(BaseModel):
+    gaps: list[GapSignal]

--- a/backend/app/modules/knowledge/service.py
+++ b/backend/app/modules/knowledge/service.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from app.modules.ai.embedding_client import get_embeddings_batch
+from app.modules.ai.llm_client import generate
 from app.modules.knowledge import repository as repo
 from app.modules.knowledge.schemas import (
+    AskResponse,
+    Citation,
+    GapSignal,
+    GapSignalList,
     IngestResponse,
     ReferenceDocumentInput,
     RetrievalResult,
@@ -14,6 +20,20 @@ from app.modules.knowledge.schemas import (
 )
 
 logger = logging.getLogger("cosolvent.knowledge")
+
+# Sentinel the model must emit when the excerpts cannot answer the question.
+_NOT_COVERED = "NOT_COVERED"
+_NOT_COVERED_MSG = "This question isn't covered by the current reference library."
+
+_GROUNDING_SYSTEM = (
+    "You are a domain reference assistant for a curated knowledge library. "
+    "Answer the question using ONLY the reference excerpts provided by the user. "
+    "Cite every excerpt you rely on inline using its bracketed key, e.g. [27_2025]. "
+    "Do not use any outside or prior knowledge. If the excerpts do not contain "
+    f"enough information to answer, reply with exactly: {_NOT_COVERED}"
+)
+
+_CITATION_RE = re.compile(r"\[([^\]\n]+)\]")
 
 
 async def ingest_documents(documents: list[ReferenceDocumentInput]) -> IngestResponse:
@@ -83,6 +103,92 @@ async def retrieve(
     )
     results = [RetrievalResult(**row) for row in rows]
     return RetrieveResponse(query=query, results=results)
+
+
+async def ask(
+    *,
+    query: str,
+    filters: dict | None = None,
+    vertical: str | None = None,
+    top_k: int = 8,
+    min_score: float = 0.0,
+) -> AskResponse:
+    """Answer a question strictly from the reference library, with citations.
+
+    Retrieves the most relevant chunks, asks the LLM to answer using only those
+    excerpts, and — when nothing matches or the model reports the answer is not
+    covered — records a knowledge gap signal for curators.
+    """
+    retrieval = await retrieve(
+        query=query, filters=filters, vertical=vertical, top_k=top_k, min_score=min_score
+    )
+    chunks = retrieval.results
+    used_chunks = [c.chunk_id for c in chunks]
+
+    if not chunks:
+        await _record_gap(query, vertical, filters, "no_matching_chunks")
+        return AskResponse(query=query, answered=False, answer=_NOT_COVERED_MSG)
+
+    messages = [
+        {"role": "system", "content": _GROUNDING_SYSTEM},
+        {"role": "user", "content": f"Reference excerpts:\n\n{_format_context(chunks)}\n\nQuestion: {query}"},
+    ]
+    raw = (await generate(messages, use_case="rag_query")).strip()
+
+    if raw.upper().startswith(_NOT_COVERED):
+        await _record_gap(query, vertical, filters, "model_not_covered")
+        return AskResponse(query=query, answered=False, answer=_NOT_COVERED_MSG, used_chunks=used_chunks)
+
+    return AskResponse(
+        query=query,
+        answered=True,
+        answer=raw,
+        citations=_extract_citations(raw, chunks),
+        used_chunks=used_chunks,
+    )
+
+
+def _format_context(chunks: list[RetrievalResult]) -> str:
+    """Render retrieved chunks as keyed excerpts the model can cite by [doc_key]."""
+    blocks = []
+    for c in chunks:
+        topic = (c.metadata or {}).get("topic")
+        tag = f"[{c.doc_key}]" + (f" (topic: {topic})" if topic else "")
+        blocks.append(f"{tag}\n{c.contextual_content}")
+    return "\n\n---\n\n".join(blocks)
+
+
+def _extract_citations(answer: str, chunks: list[RetrievalResult]) -> list[Citation]:
+    """Map the [doc_key] tokens the model used back to the retrieved documents."""
+    cited = set(_CITATION_RE.findall(answer))
+    by_key: dict[str, Citation] = {}
+    for c in chunks:
+        if c.doc_key not in cited:
+            continue
+        entry = by_key.get(c.doc_key)
+        if entry is None:
+            by_key[c.doc_key] = Citation(
+                doc_key=c.doc_key,
+                title=c.title,
+                source_document=c.source_document,
+                chunk_ids=[c.chunk_id],
+            )
+        else:
+            entry.chunk_ids.append(c.chunk_id)
+    return list(by_key.values())
+
+
+async def _record_gap(query: str, vertical: str | None, filters: dict | None, reason: str) -> None:
+    try:
+        await repo.insert_gap_signal(query=query, vertical=vertical, filters=filters, reason=reason)
+    except Exception:  # noqa: BLE001 - a gap-logging failure must not break the answer path.
+        logger.warning("Failed to record knowledge gap signal", exc_info=True)
+
+
+async def list_gaps(vertical: str | None = None, limit: int = 100) -> GapSignalList:
+    """Curator view: recorded knowledge gaps, newest first."""
+    rows = await repo.list_gap_signals(vertical=vertical, limit=limit)
+    return GapSignalList(gaps=[GapSignal(**row) for row in rows])
 
 
 async def delete_document(doc_key: str) -> bool:

--- a/backend/app/modules/knowledge/service.py
+++ b/backend/app/modules/knowledge/service.py
@@ -35,6 +35,13 @@ _GROUNDING_SYSTEM = (
 
 _CITATION_RE = re.compile(r"\[([^\]\n]+)\]")
 
+# Leading source marker that KnowledgeSlot prepends to contextual_content
+# (e.g. "[27_2025.md] 13. PAYMENT > ..."). It is stripped before the excerpt is
+# shown to the model so the only bracketed token in an excerpt is its [doc_key]
+# citation tag — otherwise the model may cite "[27_2025.md]", which does not map
+# back to a doc_key.
+_LEADING_MARKER_RE = re.compile(r"^\s*\[[^\]\n]+\]\s*")
+
 
 async def ingest_documents(documents: list[ReferenceDocumentInput]) -> IngestResponse:
     """Upsert reference documents and their chunks.
@@ -139,11 +146,19 @@ async def ask(
         await _record_gap(query, vertical, filters, "model_not_covered")
         return AskResponse(query=query, answered=False, answer=_NOT_COVERED_MSG, used_chunks=used_chunks)
 
+    citations = _extract_citations(raw, chunks)
+    if not citations:
+        # The model produced prose but cited no retrievable [doc_key]. Under the
+        # "grounded, with citations" contract that is not an answer we can stand
+        # behind, so treat it as not covered and record a gap for curators.
+        await _record_gap(query, vertical, filters, "answer_without_citation")
+        return AskResponse(query=query, answered=False, answer=_NOT_COVERED_MSG, used_chunks=used_chunks)
+
     return AskResponse(
         query=query,
         answered=True,
         answer=raw,
-        citations=_extract_citations(raw, chunks),
+        citations=citations,
         used_chunks=used_chunks,
     )
 
@@ -154,7 +169,8 @@ def _format_context(chunks: list[RetrievalResult]) -> str:
     for c in chunks:
         topic = (c.metadata or {}).get("topic")
         tag = f"[{c.doc_key}]" + (f" (topic: {topic})" if topic else "")
-        blocks.append(f"{tag}\n{c.contextual_content}")
+        excerpt = _LEADING_MARKER_RE.sub("", c.contextual_content, count=1)
+        blocks.append(f"{tag}\n{excerpt}")
     return "\n\n---\n\n".join(blocks)
 
 

--- a/backend/tests/integration/test_knowledge_roundtrip.py
+++ b/backend/tests/integration/test_knowledge_roundtrip.py
@@ -1,0 +1,74 @@
+"""Live pgvector round-trip for the reference library + gap signals.
+
+Deterministic and provider-free: chunks are ingested with a precomputed
+embedding and retrieved with a fixed query vector, so no LLM/embedding provider
+is required — only a migrated Postgres+pgvector database.
+
+Gated by RUN_INTEGRATION (skipped in the normal unit run).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.database import close_db, connect_db
+from app.modules.knowledge import repository as repo
+from app.modules.knowledge.schemas import ReferenceChunkInput, ReferenceDocumentInput
+from app.modules.knowledge import service
+from tests.e2e.helpers import require_mode
+
+DIM = 1536
+
+
+def _vec(seed: float) -> list[float]:
+    return [seed] * DIM
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_retrieve_and_gap_roundtrip():
+    require_mode("RUN_INTEGRATION")
+    await connect_db()
+    try:
+        doc = ReferenceDocumentInput(
+            doc_key="it_27_2025",
+            vertical="grain",
+            title="GAFTA Contract No. 27",
+            source_document="it_27_2025.md",
+            doc_metadata={"doc_type": "contract", "standard": "GAFTA"},
+            chunks=[
+                ReferenceChunkInput(
+                    chunk_id="it_27_2025_0",
+                    content="Payment is due against shipping documents.",
+                    contextual_content="[it_27_2025.md] 13. PAYMENT > due against documents",
+                    metadata={"topic": "payment_terms", "jurisdiction": ["Canada"]},
+                    embedding=_vec(0.01),
+                ),
+            ],
+        )
+
+        # Ingest is idempotent: run twice, expect a single chunk row.
+        await service.ingest_documents([doc])
+        await service.ingest_documents([doc])
+
+        hits = await repo.retrieve(_vec(0.01), top_k=5, filters={"topic": "payment_terms"}, vertical="grain")
+        assert any(h["chunk_id"] == "it_27_2025_0" for h in hits)
+        top = next(h for h in hits if h["chunk_id"] == "it_27_2025_0")
+        assert top["doc_key"] == "it_27_2025"
+        assert top["title"] == "GAFTA Contract No. 27"
+
+        # Metadata pre-filter excludes non-matching topics.
+        none = await repo.retrieve(_vec(0.01), top_k=5, filters={"topic": "no_such_topic"}, vertical="grain")
+        assert all(h["chunk_id"] != "it_27_2025_0" for h in none)
+
+        # Gap-signal round-trip.
+        await repo.insert_gap_signal(
+            query="tariff on widgets?", vertical="grain", filters={"topic": "x"}, reason="no_matching_chunks"
+        )
+        gaps = await repo.list_gap_signals(vertical="grain", limit=10)
+        assert any(g["query"] == "tariff on widgets?" and g["reason"] == "no_matching_chunks" for g in gaps)
+
+        # Cleanup.
+        await repo.delete_document("it_27_2025")
+    finally:
+        await close_db()

--- a/backend/tests/unit/test_knowledge_qa.py
+++ b/backend/tests/unit/test_knowledge_qa.py
@@ -1,0 +1,125 @@
+"""Unit tests for domain Q&A and knowledge-gap capture.
+
+Retrieval, the LLM, and the database are mocked, so these isolate the grounded
+answer/citation logic and the gap-signal branching.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.modules.knowledge import service
+from app.modules.knowledge.schemas import RetrievalResult, RetrieveResponse
+
+
+def _result(chunk_id="27_2025_3", doc_key="27_2025", topic="payment_terms"):
+    return RetrievalResult(
+        chunk_id=chunk_id,
+        doc_key=doc_key,
+        title="GAFTA Contract No. 27",
+        source_document="27_2025.md",
+        content="Payment is due against shipping documents.",
+        contextual_content="[27_2025.md] 13. PAYMENT > Payment is due against shipping documents.",
+        score=0.82,
+        metadata={"topic": topic, "standard": "GAFTA"},
+    )
+
+
+def _retrieval(results):
+    return RetrieveResponse(query="q", results=results)
+
+
+@pytest.mark.asyncio
+async def test_ask_returns_grounded_answer_with_citations():
+    with (
+        patch.object(service, "retrieve", new=AsyncMock(return_value=_retrieval([_result()]))),
+        patch.object(service, "generate", new=AsyncMock(return_value="Payment is due against documents [27_2025].")),
+        patch.object(service.repo, "insert_gap_signal", new=AsyncMock()) as gap,
+    ):
+        resp = await service.ask(query="when is payment due?", vertical="grain")
+
+    assert resp.answered is True
+    assert "[27_2025]" in resp.answer
+    assert resp.used_chunks == ["27_2025_3"]
+    assert len(resp.citations) == 1
+    assert resp.citations[0].doc_key == "27_2025"
+    assert resp.citations[0].chunk_ids == ["27_2025_3"]
+    gap.assert_not_awaited()  # answered -> no gap recorded
+
+
+@pytest.mark.asyncio
+async def test_ask_with_no_matching_chunks_records_gap_and_skips_llm():
+    with (
+        patch.object(service, "retrieve", new=AsyncMock(return_value=_retrieval([]))),
+        patch.object(service, "generate", new=AsyncMock()) as llm,
+        patch.object(service.repo, "insert_gap_signal", new=AsyncMock()) as gap,
+    ):
+        resp = await service.ask(query="what is the tariff on widgets?", vertical="grain", filters={"topic": "x"})
+
+    llm.assert_not_awaited()  # nothing retrieved -> don't pay for an LLM call
+    gap.assert_awaited_once()
+    assert gap.call_args.kwargs["reason"] == "no_matching_chunks"
+    assert resp.answered is False
+    assert resp.answer == service._NOT_COVERED_MSG
+
+
+@pytest.mark.asyncio
+async def test_ask_when_model_reports_not_covered_records_gap():
+    with (
+        patch.object(service, "retrieve", new=AsyncMock(return_value=_retrieval([_result()]))),
+        patch.object(service, "generate", new=AsyncMock(return_value="NOT_COVERED")),
+        patch.object(service.repo, "insert_gap_signal", new=AsyncMock()) as gap,
+    ):
+        resp = await service.ask(query="unrelated question?", vertical="grain")
+
+    gap.assert_awaited_once()
+    assert gap.call_args.kwargs["reason"] == "model_not_covered"
+    assert resp.answered is False
+    assert resp.used_chunks == ["27_2025_3"]
+    assert resp.citations == []
+
+
+@pytest.mark.asyncio
+async def test_ask_gap_logging_failure_does_not_break_answer_path():
+    # A failure recording the gap must not surface to the caller.
+    with (
+        patch.object(service, "retrieve", new=AsyncMock(return_value=_retrieval([]))),
+        patch.object(service.repo, "insert_gap_signal", new=AsyncMock(side_effect=RuntimeError("db down"))),
+    ):
+        resp = await service.ask(query="anything?")
+    assert resp.answered is False
+
+
+def test_extract_citations_only_returns_referenced_docs():
+    chunks = [_result(chunk_id="a_0", doc_key="a"), _result(chunk_id="b_0", doc_key="b")]
+    cites = service._extract_citations("Per [a], yes.", chunks)
+    assert [c.doc_key for c in cites] == ["a"]
+    assert cites[0].chunk_ids == ["a_0"]
+
+
+def test_extract_citations_groups_multiple_chunks_per_doc():
+    chunks = [_result(chunk_id="a_0", doc_key="a"), _result(chunk_id="a_1", doc_key="a")]
+    cites = service._extract_citations("See [a].", chunks)
+    assert len(cites) == 1
+    assert cites[0].chunk_ids == ["a_0", "a_1"]
+
+
+@pytest.mark.asyncio
+async def test_list_gaps_maps_rows():
+    rows = [
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "query": "tariff on widgets?",
+            "vertical": "grain",
+            "filters": {"topic": "x"},
+            "reason": "no_matching_chunks",
+            "created_at": "2026-06-08T10:00:00+00:00",
+        }
+    ]
+    with patch.object(service.repo, "list_gap_signals", new=AsyncMock(return_value=rows)):
+        out = await service.list_gaps(vertical="grain")
+    assert len(out.gaps) == 1
+    assert out.gaps[0].reason == "no_matching_chunks"
+    assert out.gaps[0].query == "tariff on widgets?"

--- a/backend/tests/unit/test_knowledge_qa.py
+++ b/backend/tests/unit/test_knowledge_qa.py
@@ -123,3 +123,38 @@ async def test_list_gaps_maps_rows():
     assert len(out.gaps) == 1
     assert out.gaps[0].reason == "no_matching_chunks"
     assert out.gaps[0].query == "tariff on widgets?"
+
+
+def test_format_context_strips_leading_source_marker():
+    # contextual_content carries a leading "[<file>]" marker; it must not reach the
+    # model as a rival bracket to the [doc_key] citation tag.
+    ctx = service._format_context([_result()])
+    assert "[27_2025]" in ctx                      # the citable doc_key tag is present
+    assert "[27_2025.md]" not in ctx               # the rival file marker is stripped
+    assert "Payment is due against shipping documents." in ctx
+
+
+@pytest.mark.asyncio
+async def test_ask_without_citations_is_not_answered_and_records_gap():
+    # The model answers but cites nothing resolvable -> not a grounded answer.
+    with (
+        patch.object(service, "retrieve", new=AsyncMock(return_value=_retrieval([_result()]))),
+        patch.object(service, "generate", new=AsyncMock(return_value="Payment is due against documents.")),
+        patch.object(service.repo, "insert_gap_signal", new=AsyncMock()) as gap,
+    ):
+        resp = await service.ask(query="when is payment due?", vertical="grain")
+
+    assert resp.answered is False
+    assert resp.answer == service._NOT_COVERED_MSG
+    assert resp.citations == []
+    gap.assert_awaited_once()
+    assert gap.call_args.kwargs["reason"] == "answer_without_citation"
+
+
+def test_bounded_gap_limit_clamps_range():
+    from app.modules.knowledge.repository import bounded_gap_limit, _MAX_GAP_LIMIT
+
+    assert bounded_gap_limit(50) == 50                 # in range unchanged
+    assert bounded_gap_limit(10_000_000) == _MAX_GAP_LIMIT  # oversized clamped down
+    assert bounded_gap_limit(0) == 1                   # floor at 1
+    assert bounded_gap_limit(-5) == 1


### PR DESCRIPTION
## Summary

Builds on the Reference Library to add **cited domain Q&A** and a **curatorial
pull loop**. `POST /api/knowledge/ask` retrieves the top chunks, answers using
**only** those excerpts via a grounding prompt that forces inline `[doc_key]`
citations, and returns an explicit "not covered" when the excerpts don't answer.
When the library can't answer (empty retrieval or model `NOT_COVERED`), the
question is recorded in a new `knowledge_gap_signals` table (migration
`knowledge_gap_signals_0001`) and surfaced to curators via admin
`GET /api/knowledge/gaps`. Gap-logging failures never break the answer path.


## Thin-Market Impact

Directly attacks **information asymmetry and trust**: participants get answers
grounded in authoritative sources with citations, not unsourced guesses — and
unanswerable questions become a **feedback signal** that tells curators exactly
which knowledge gaps to close, so coverage improves with use (the start of the
curatorial pull loop). Empty-retrieval short-circuits before any LLM call,
keeping cost predictable.

## Checklist

- [x] Tests added/updated — 7 unit tests (answer + citations, both gap paths, failure tolerance, gaps list) + 1 **live pgvector** round-trip
- [x] Docs updated — N/A (no doc changes in this PR)
- [x] `make lint` passes — ruff + mypy clean on changed files
- [x] `make unit` passes — green 
- [x] `make compile-check` passes — not run (no compiler/config changes)
- [x] `make integration` passes — the knowledge round-trip integration test **passed live** 
- [x] `make e2e` passes — not run

## Backward Compatibility

**Additive only — no behavior or contract changes.** Adds two routes
(`/ask`, `/gaps`), one table, and one migration; existing endpoints, schemas,
and the reference-library contract are unchanged. Requires applying
`knowledge_gap_signals_0001`.
