### PR TITLE
Fix broken Alembic migration chain

### DIFF
--- a/backend/alembic/versions/auto_marketplace_mkt_5ed8adda2d87.py
+++ b/backend/alembic/versions/auto_marketplace_mkt_5ed8adda2d87.py
@@ -95,6 +95,13 @@ def upgrade() -> None:
         UNIQUE (role_id, section_name, field_name)
     )
     """)
+    # The earlier snapshot (mkt_cd0965b20114) created this table before the
+    # accepted_types_json column existed, so the CREATE TABLE IF NOT EXISTS above
+    # is a no-op on an already-migrated DB and the seed INSERT below would hit a
+    # missing column. ADD COLUMN IF NOT EXISTS is idempotent and safe on a
+    # populated table (and also fixes the column for the later fdc097 snapshot).
+    op.execute("ALTER TABLE marketplace_profile_field_defs ADD COLUMN IF NOT EXISTS options_json JSONB NULL")
+    op.execute("ALTER TABLE marketplace_profile_field_defs ADD COLUMN IF NOT EXISTS accepted_types_json JSONB NULL")
     op.execute("""
     CREATE TABLE IF NOT EXISTS marketplace_builds (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/backend/alembic/versions/auto_marketplace_mkt_fdc097f304d2.py
+++ b/backend/alembic/versions/auto_marketplace_mkt_fdc097f304d2.py
@@ -11,7 +11,10 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "mkt_fdc097f304d2"
-down_revision = "mkt_670a55764f43"
+# Reparented from the deleted snapshot "mkt_670a55764f43" onto the surviving
+# marketplace tip so the migration graph is whole again (the missing revision
+# was a regenerated snapshot that was removed, leaving this one dangling).
+down_revision = "mkt_5ed8adda2d87"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/merge_heads_0001.py
+++ b/backend/alembic/versions/merge_heads_0001.py
@@ -1,0 +1,28 @@
+"""Merge the marketplace and knowledge migration heads into one.
+
+The graph had two heads after the reference-library/Q&A work landed on a
+separate branch from the regenerated marketplace snapshot:
+  * mkt_fdc097f304d2        (marketplace metadata)
+  * knowledge_gap_signals_0001 (reference-library gap signals)
+This is a no-op merge revision so `alembic upgrade head` resolves to a single head.
+
+Revision ID: merge_heads_0001
+Revises: mkt_fdc097f304d2, knowledge_gap_signals_0001
+Create Date: 2026-07-26
+"""
+
+from __future__ import annotations
+
+# revision identifiers, used by Alembic.
+revision = "merge_heads_0001"
+down_revision = ("mkt_fdc097f304d2", "knowledge_gap_signals_0001")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
`alembic upgrade head` currently fails on `main`. This fixes three independent breaks in the migration graph so the backend can migrate cleanly again.

## What was broken → fixed
- **Dangling revision.** `auto_marketplace_mkt_fdc097f304d2` had `down_revision = "mkt_670a55764f43"`, a regenerated marketplace snapshot that was later deleted — making the graph unresolvable (`KeyError: mkt_670a55764f43`). **Reparented** it onto the surviving marketplace tip `mkt_5ed8adda2d87`.
- **Missing column at seed time.** `mkt_5ed8adda2d87` seeds `marketplace_profile_field_defs` with `accepted_types_json`, but the earlier snapshot created that table without the column and `CREATE TABLE IF NOT EXISTS` can't add it → `UndefinedColumnError`. Added an idempotent **`ADD COLUMN IF NOT EXISTS`** (`accepted_types_json`, `options_json`) before the seed; this also covers the later `fdc097` snapshot.
- **Multiple heads.** The marketplace and knowledge (reference-library gap-signals) lineages had diverged into two heads. Added **`merge_heads_0001`** to unify them into a single head.

## Verified
`alembic upgrade head` now runs clean end-to-end on a fresh Postgres + pgvector database to a single head (`merge_heads_0001`), with `alembic current == heads`.