### PR TITLE
Config-driven match scoring + hard gates (GAP-3)

### DIFF
--- a/backend/app/core/marketplace_config.py
+++ b/backend/app/core/marketplace_config.py
@@ -11,7 +11,7 @@ import re
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 _ROLE_SLUG_RE = re.compile(r"^[a-z][a-z0-9_-]{1,63}$")
 
@@ -181,12 +181,67 @@ class DiscoveryAccessConfig(StrictModel):
     anonymous_filter_mode: Literal["public_only", "none", "all"] = "public_only"
 
 
+# ── Match scoring & gating (GAP-3) ────────────────────────────────────────
+# A weighted, config-driven scoring model layered over semantic similarity:
+# composite = vector_weight * vector + Σ slot.weight * slot_score, and hard gates
+# that exclude structurally incompatible candidates before they are ranked.
+
+class MatchSlot(StrictModel):
+    """One weighted soft dimension of the match score."""
+    name: str
+    fields: list[str]
+    # How the slot's fields are compared into a [0,1] score:
+    #   scalar_eq         — 1.0 if equal, else 0.0 (per field, averaged)
+    #   jaccard           — set overlap (lists, or scalars as singletons)
+    #   numeric_proximity — 1 - normalized absolute difference
+    comparator: Literal["scalar_eq", "jaccard", "numeric_proximity"] = "scalar_eq"
+    weight: float = Field(ge=0.0, le=1.0)
+
+
+class HardGate(StrictModel):
+    """A mandatory condition on a candidate field; failing it excludes the match."""
+    name: str
+    field: str
+    op: Literal["equals", "in", "gte", "lte", "present"] = "equals"
+    value: Any = None  # unused for op == "present"
+
+
+class MatchProfile(StrictModel):
+    """The scoring weight table + gates used against one target type."""
+    vector_weight: float = Field(default=0.5, ge=0.0, le=1.0)
+    slots: list[MatchSlot] = []
+    hard_gates: list[HardGate] = []
+
+    @model_validator(mode="after")
+    def _weights_sum_to_one(self) -> "MatchProfile":
+        total = self.vector_weight + sum(s.weight for s in self.slots)
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError(
+                f"matching weights must sum to 1.0 (vector_weight + slot weights = {total:.4f})"
+            )
+        names = [s.name for s in self.slots]
+        if len(names) != len(set(names)):
+            raise ValueError("matching slot names must be unique")
+        return self
+
+
+class MatchingConfig(StrictModel):
+    """Optional per-target scoring/gating. Absent → the engine uses its legacy
+    semantic + field-overlap blend, so existing configs keep working unchanged."""
+    default: MatchProfile | None = None
+    per_target: dict[str, MatchProfile] = {}
+
+    def profile_for(self, target_type: str) -> MatchProfile | None:
+        return self.per_target.get(target_type) or self.default
+
+
 class DiscoveryConfig(StrictModel):
     searchable_types: list[str]
     filter_fields: list[str] = []
     result_visibility: ResultVisibility = ResultVisibility()
     ai: AIDiscoveryConfig = AIDiscoveryConfig()
     access: DiscoveryAccessConfig = DiscoveryAccessConfig()
+    matching: MatchingConfig = MatchingConfig()
 
 
 # ── Marketplace identity ─────────────────────────────────────────────────
@@ -439,6 +494,26 @@ class MarketplaceConfig(StrictModel):
         for ff in self.discovery.filter_fields:
             if ff not in all_field_names:
                 raise ValueError(f"Discovery filter_field '{ff}' not found in any profile schema")
+
+        # Matching config: per_target keys must be valid slugs; slot/gate fields must exist.
+        matching = self.discovery.matching
+        for tgt in matching.per_target:
+            if tgt not in slugs:
+                raise ValueError(f"Discovery matching per_target references unknown type '{tgt}'")
+        for mp in [matching.default, *matching.per_target.values()]:
+            if mp is None:
+                continue
+            for slot in mp.slots:
+                for fld in slot.fields:
+                    if fld not in all_field_names:
+                        raise ValueError(
+                            f"Matching slot '{slot.name}' references unknown field '{fld}'"
+                        )
+            for gate in mp.hard_gates:
+                if gate.field not in all_field_names:
+                    raise ValueError(
+                        f"Matching hard_gate '{gate.name}' references unknown field '{gate.field}'"
+                    )
 
         return self
 

--- a/backend/app/modules/discovery/matching.py
+++ b/backend/app/modules/discovery/matching.py
@@ -87,47 +87,83 @@ async def suggested_matches(
     # as an authenticated peer (which honors discovery.result_visibility).
     candidate_tier = "owner" if is_admin else "authenticated"
 
+    # When the marketplace declares a matching profile for this target, use the
+    # config-driven weighted-slot + hard-gate model; otherwise fall back to the
+    # legacy semantic + field-overlap blend (keeps existing configs working).
+    match_profile = config.discovery.matching.profile_for(resolved_target)
+
     results: list[dict[str, Any]] = []
+    gated: list[dict[str, Any]] = []
     for cand in candidates:
         cand_profile = cand.get("profile", {}) or {}
         cand_fields = cand_profile.get("fields", {}) or {}
         vector_score = float(cand.get("score", 0.0))
-        overlap = _compute_field_overlap(
-            config.discovery.filter_fields,
-            self_fields,
-            cand_fields,
-        )
-        composite = VECTOR_WEIGHT * vector_score + FIELD_OVERLAP_WEIGHT * overlap
 
         filtered_fields = (
             filter_fields_for_discovery(config, target_schema, cand_fields, candidate_tier)
             if target_schema
             else {}
         )
+        entry: dict[str, Any] = {
+            "id": cand["id"],
+            "participant_type": resolved_target,
+            "fields": filtered_fields,
+        }
 
-        results.append(
-            {
-                "id": cand["id"],
-                "participant_type": resolved_target,
-                "score": round(composite, 6),
-                "score_breakdown": {
-                    "vector": round(vector_score, 6),
-                    "field_overlap": round(overlap, 6),
-                    "vector_weight": VECTOR_WEIGHT,
-                    "field_overlap_weight": FIELD_OVERLAP_WEIGHT,
-                },
-                "fields": filtered_fields,
+        if match_profile is None:
+            overlap = _compute_field_overlap(config.discovery.filter_fields, self_fields, cand_fields)
+            composite = VECTOR_WEIGHT * vector_score + FIELD_OVERLAP_WEIGHT * overlap
+            entry["score"] = round(composite, 6)
+            entry["score_breakdown"] = {
+                "vector": round(vector_score, 6),
+                "field_overlap": round(overlap, 6),
+                "vector_weight": VECTOR_WEIGHT,
+                "field_overlap_weight": FIELD_OVERLAP_WEIGHT,
             }
-        )
+            results.append(entry)
+            continue
 
-    # Re-sort by the composite score because field overlap can reorder candidates
+        # Config-driven scoring: composite = vector_weight·vector + Σ slot.weight·slot_score.
+        composite = match_profile.vector_weight * vector_score
+        slot_detail: dict[str, Any] = {}
+        for slot in match_profile.slots:
+            s = _slot_score(slot.comparator, self_fields, cand_fields, slot.fields)
+            composite += slot.weight * s
+            slot_detail[slot.name] = {"score": round(s, 6), "weight": slot.weight}
+
+        gate_results = _evaluate_gates(cand_fields, match_profile.hard_gates)
+        entry["score"] = round(composite, 6)
+        entry["score_breakdown"] = {
+            "vector": round(vector_score, 6),
+            "vector_weight": match_profile.vector_weight,
+            "slots": slot_detail,
+            "gates": gate_results,
+        }
+
+        failures = [g for g in gate_results if not g["passed"]]
+        if failures:
+            # A hard-gate failure excludes the candidate from the ranked list, but it
+            # is returned (flagged, with reasons) so the "why gated out" is visible and
+            # a future alternative-compliance layer can act on it.
+            entry["gated"] = True
+            entry["gate_failures"] = [g["name"] for g in failures]
+            gated.append(entry)
+        else:
+            results.append(entry)
+
+    # Re-sort by the composite score because slots/overlap can reorder candidates
     # that the SQL layer ranked purely by cosine distance.
     results.sort(key=lambda r: (-r["score"], r["id"]))
-    return {
+    gated.sort(key=lambda r: (-r["score"], r["id"]))
+
+    out: dict[str, Any] = {
         "results": results,
         "total": len(results),
         "target_type": resolved_target,
     }
+    if match_profile is not None:
+        out["gated"] = gated
+    return out
 
 
 def _resolve_target_type(
@@ -216,3 +252,74 @@ def _compute_field_overlap(
     if not scores:
         return 0.0
     return sum(scores) / len(scores)
+
+
+# ── Config-driven slot scoring & hard gates (GAP-3) ───────────────────────
+
+def _num(v: Any) -> float | None:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pair_score(comparator: str, a: Any, b: Any) -> float | None:
+    """Compare one field on both sides into [0,1]; None when not comparable."""
+    if a is None or b is None:
+        return None
+    if comparator == "jaccard":
+        a_set = set(a) if isinstance(a, list) else {a}
+        b_set = set(b) if isinstance(b, list) else {b}
+        union = a_set | b_set
+        return (len(a_set & b_set) / len(union)) if union else None
+    if comparator == "numeric_proximity":
+        na, nb = _num(a), _num(b)
+        if na is None or nb is None:
+            return None
+        denom = max(abs(na), abs(nb), 1.0)
+        return max(0.0, 1.0 - abs(na - nb) / denom)
+    # scalar_eq (default)
+    return 1.0 if a == b else 0.0
+
+
+def _slot_score(comparator: str, source_fields: dict[str, Any], cand_fields: dict[str, Any],
+                fields: list[str]) -> float:
+    """Mean of the per-field comparator scores for the slot's fields present on
+    both sides. Returns 0.0 when no field is comparable."""
+    scores = [
+        s for f in fields
+        if (s := _pair_score(comparator, source_fields.get(f), cand_fields.get(f))) is not None
+    ]
+    return sum(scores) / len(scores) if scores else 0.0
+
+
+def _check_gate(val: Any, gate: Any) -> tuple[bool, str]:
+    op = gate.op
+    if op == "present":
+        return (val not in (None, "", [])), f"{gate.field} is required"
+    if val is None:
+        return False, f"{gate.field} is missing"
+    if op == "equals":
+        return (val == gate.value), f"{gate.field} must equal {gate.value!r} (got {val!r})"
+    if op == "in":
+        allowed = gate.value if isinstance(gate.value, list) else [gate.value]
+        vals = val if isinstance(val, list) else [val]
+        return (any(v in allowed for v in vals)), f"{gate.field} must be one of {allowed} (got {val!r})"
+    if op in ("gte", "lte"):
+        nv, gv = _num(val), _num(gate.value)
+        if nv is None or gv is None:
+            return False, f"{gate.field} must be numeric to compare {op} {gate.value!r} (got {val!r})"
+        ok = nv >= gv if op == "gte" else nv <= gv
+        return ok, f"{gate.field} must be {op} {gate.value} (got {val!r})"
+    return True, ""
+
+
+def _evaluate_gates(cand_fields: dict[str, Any], gates: list[Any]) -> list[dict[str, Any]]:
+    """Evaluate every hard gate against a candidate's fields; a failed gate carries
+    a human-readable reason ('why gated out')."""
+    out: list[dict[str, Any]] = []
+    for gate in gates:
+        passed, reason = _check_gate(cand_fields.get(gate.field), gate)
+        out.append({"name": gate.name, "field": gate.field, "passed": passed,
+                    "reason": None if passed else reason})
+    return out

--- a/backend/app/modules/discovery/schemas.py
+++ b/backend/app/modules/discovery/schemas.py
@@ -18,11 +18,28 @@ class SearchResult(BaseModel):
     ai_profile: str | None = None
 
 
+class SuggestedMatchSlot(BaseModel):
+    score: float
+    weight: float
+
+
+class SuggestedMatchGate(BaseModel):
+    name: str
+    field: str
+    passed: bool
+    reason: str | None = None
+
+
 class SuggestedMatchScoreBreakdown(BaseModel):
     vector: float
-    field_overlap: float
     vector_weight: float
-    field_overlap_weight: float
+    # Legacy field-overlap blend — present when no matching profile is configured.
+    field_overlap: float | None = None
+    field_overlap_weight: float | None = None
+    # Config-driven weighted slots + hard gates (GAP-3) — present when a matching
+    # profile is configured for the target type.
+    slots: dict[str, SuggestedMatchSlot] | None = None
+    gates: list[SuggestedMatchGate] | None = None
 
 
 class SuggestedMatchResult(BaseModel):
@@ -31,9 +48,16 @@ class SuggestedMatchResult(BaseModel):
     score: float
     score_breakdown: SuggestedMatchScoreBreakdown
     fields: dict
+    # Set on candidates excluded by a hard gate (returned in the response's `gated`
+    # list so the "why gated out" reasons are visible).
+    gated: bool | None = None
+    gate_failures: list[str] | None = None
 
 
 class SuggestedMatchesResponse(BaseModel):
     results: list[SuggestedMatchResult]
     total: int
     target_type: str
+    # Candidates excluded by hard gates, ranked; only present when a matching
+    # profile is configured.
+    gated: list[SuggestedMatchResult] | None = None

--- a/backend/tests/unit/test_matching_gap3.py
+++ b/backend/tests/unit/test_matching_gap3.py
@@ -1,0 +1,255 @@
+"""Tests for GAP-3: config-driven weighted-slot scoring + hard gates.
+
+Covers the pure comparator/gate helpers, the matching config validation, and the
+config-driven path of suggested_matches (composite from weights, hard-gate
+exclusion, and the score explanation). Repo + vector_service are mocked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from app.core.marketplace_config import (
+    HardGate,
+    MarketplaceConfig,
+    MatchProfile,
+    MatchSlot,
+    MatchingConfig,
+    load_marketplace_config,
+)
+from app.modules.discovery import matching
+
+FIXTURES = Path(__file__).parent.parent / "test_config"
+
+
+def _producer_profile() -> dict:
+    return {
+        "_id": "p-1", "user_id": "u-1", "participant_type": "producer", "status": "active",
+        "fields": {"country": "Canada", "primary_crops": ["Wheat", "Barley"]},
+    }
+
+
+def _buyer_candidate(pid: str, score: float, fields: dict) -> dict:
+    return {
+        "id": pid, "score": score, "metadata": {"participant_type": "buyer"},
+        "profile": {"_id": pid, "user_id": f"bu-{pid}", "participant_type": "buyer",
+                    "status": "active", "fields": {"org_name": "Acme", **fields}},
+    }
+
+
+# ── comparator helpers ────────────────────────────────────────────────────
+
+def test_pair_score_scalar_eq():
+    assert matching._pair_score("scalar_eq", "Canada", "Canada") == 1.0
+    assert matching._pair_score("scalar_eq", "Canada", "USA") == 0.0
+    assert matching._pair_score("scalar_eq", None, "Canada") is None
+
+
+def test_pair_score_jaccard():
+    assert matching._pair_score("jaccard", ["a", "b"], ["a", "c"]) == pytest.approx(1 / 3)
+    assert matching._pair_score("jaccard", "a", ["a", "b"]) == pytest.approx(0.5)
+
+
+def test_pair_score_numeric_proximity():
+    assert matching._pair_score("numeric_proximity", 100, 100) == 1.0
+    assert matching._pair_score("numeric_proximity", 100, 50) == pytest.approx(0.5)
+    assert matching._pair_score("numeric_proximity", 100, 0) == 0.0
+    assert matching._pair_score("numeric_proximity", "x", 5) is None
+
+
+def test_slot_score_averages_present_fields():
+    s = matching._slot_score("scalar_eq", {"a": "1", "b": "2"}, {"a": "1", "b": "9"}, ["a", "b"])
+    assert s == pytest.approx(0.5)
+    # no comparable fields -> 0.0
+    assert matching._slot_score("scalar_eq", {"a": "1"}, {"b": "2"}, ["a", "b"]) == 0.0
+
+
+# ── hard gates ────────────────────────────────────────────────────────────
+
+def test_check_gate_operators():
+    eq = HardGate(name="g", field="country", op="equals", value="Canada")
+    assert matching._check_gate("Canada", eq)[0] is True
+    assert matching._check_gate("USA", eq)[0] is False
+    assert matching._check_gate(None, eq)[0] is False  # missing fails
+
+    present = HardGate(name="g", field="cwi", op="present")
+    assert matching._check_gate("yes", present)[0] is True
+    assert matching._check_gate([], present)[0] is False
+
+    in_ = HardGate(name="g", field="country", op="in", value=["Canada", "USA"])
+    assert matching._check_gate("USA", in_)[0] is True
+    assert matching._check_gate("Brazil", in_)[0] is False
+
+    gte = HardGate(name="g", field="cap", op="gte", value=100)
+    assert matching._check_gate(150, gte)[0] is True
+    assert matching._check_gate(50, gte)[0] is False
+
+
+def test_evaluate_gates_reports_reasons():
+    gates = [HardGate(name="ca_only", field="country", op="equals", value="Canada")]
+    res = matching._evaluate_gates({"country": "USA"}, gates)
+    assert res[0]["passed"] is False
+    assert "country" in res[0]["reason"]
+    ok = matching._evaluate_gates({"country": "Canada"}, gates)
+    assert ok[0]["passed"] is True and ok[0]["reason"] is None
+
+
+# ── matching config validation ────────────────────────────────────────────
+
+def test_match_profile_weights_must_sum_to_one():
+    with pytest.raises(ValidationError):
+        MatchProfile(vector_weight=0.5, slots=[MatchSlot(name="g", fields=["country"], weight=0.2)])
+    # valid: 0.6 + 0.4 == 1.0
+    MatchProfile(vector_weight=0.6, slots=[MatchSlot(name="g", fields=["country"], weight=0.4)])
+
+
+def test_match_profile_rejects_duplicate_slot_names():
+    with pytest.raises(ValidationError):
+        MatchProfile(
+            vector_weight=0.2,
+            slots=[MatchSlot(name="g", fields=["a"], weight=0.4),
+                   MatchSlot(name="g", fields=["b"], weight=0.4)],
+        )
+
+
+def test_matching_config_profile_for_prefers_per_target():
+    default = MatchProfile(vector_weight=1.0)
+    special = MatchProfile(vector_weight=0.5, slots=[MatchSlot(name="g", fields=["country"], weight=0.5)])
+    mc = MatchingConfig(default=default, per_target={"buyer": special})
+    assert mc.profile_for("buyer") is special
+    assert mc.profile_for("facilitator") is default
+
+
+def _agri_raw_with_matching(matching_block: dict) -> dict:
+    raw = yaml.safe_load((FIXTURES / "agriculture.yaml").read_text())
+    raw["discovery"]["matching"] = matching_block
+    return raw
+
+
+def test_cross_validate_rejects_unknown_matching_field():
+    raw = _agri_raw_with_matching(
+        {"default": {"vector_weight": 0.5, "slots": [{"name": "x", "fields": ["nope"], "weight": 0.5}]}}
+    )
+    with pytest.raises(ValueError, match="unknown field 'nope'"):
+        MarketplaceConfig(**raw)
+
+
+def test_cross_validate_rejects_unknown_per_target_type():
+    raw = _agri_raw_with_matching({"per_target": {"ghost": {"vector_weight": 1.0}}})
+    with pytest.raises(ValueError, match="unknown type 'ghost'"):
+        MarketplaceConfig(**raw)
+
+
+def test_cross_validate_accepts_valid_matching_block():
+    raw = _agri_raw_with_matching(
+        {"default": {
+            "vector_weight": 0.6,
+            "slots": [{"name": "geo", "fields": ["country"], "comparator": "scalar_eq", "weight": 0.4}],
+            "hard_gates": [{"name": "ca", "field": "country", "op": "equals", "value": "Canada"}],
+        }}
+    )
+    cfg = MarketplaceConfig(**raw)
+    assert cfg.discovery.matching.default.vector_weight == 0.6
+
+
+# ── config-driven suggested_matches ───────────────────────────────────────
+
+def _config_with_matching(profile: MatchProfile) -> MarketplaceConfig:
+    cfg = load_marketplace_config(FIXTURES / "agriculture.yaml")
+    cfg.discovery.matching = MatchingConfig(default=profile)
+    return cfg
+
+
+def _run(cfg, candidates):
+    return matching.suggested_matches(
+        cfg, profile_id="p-1", type_slug="producer", viewer={"_id": "u-1", "role": "user"},
+    ), candidates
+
+
+@pytest.mark.asyncio
+async def test_config_driven_composite_and_ranking():
+    profile = MatchProfile(
+        vector_weight=0.6,
+        slots=[MatchSlot(name="geo", fields=["country"], comparator="scalar_eq", weight=0.4)],
+    )
+    cfg = _config_with_matching(profile)
+    candidates = [
+        _buyer_candidate("buyer-a", score=0.90, fields={"country": "USA"}),
+        _buyer_candidate("buyer-b", score=0.60, fields={"country": "Canada"}),
+    ]
+    with patch.object(matching.profiles_repo, "get_profile_by_id", new=AsyncMock(return_value=_producer_profile())), \
+         patch.object(matching.vector_service, "get_profile_embedding", new=AsyncMock(return_value=[0.1] * 1536)), \
+         patch.object(matching.vector_service, "find_similar_profiles", new=AsyncMock(return_value=candidates)):
+        out = await matching.suggested_matches(
+            cfg, profile_id="p-1", type_slug="producer", viewer={"_id": "u-1", "role": "user"})
+
+    # buyer-a: 0.6*0.90 + 0.4*0.0 = 0.54 ; buyer-b: 0.6*0.60 + 0.4*1.0 = 0.76
+    assert [r["id"] for r in out["results"]] == ["buyer-b", "buyer-a"]
+    assert out["results"][0]["score"] == pytest.approx(0.76)
+    assert out["results"][1]["score"] == pytest.approx(0.54)
+    bd = out["results"][0]["score_breakdown"]
+    assert bd["vector_weight"] == 0.6
+    assert bd["slots"]["geo"] == {"score": 1.0, "weight": 0.4}
+    assert out["gated"] == []  # matching profile present -> gated key exists
+
+
+@pytest.mark.asyncio
+async def test_hard_gate_excludes_and_explains():
+    profile = MatchProfile(
+        vector_weight=0.6,
+        slots=[MatchSlot(name="geo", fields=["country"], comparator="scalar_eq", weight=0.4)],
+        hard_gates=[HardGate(name="ca_only", field="country", op="equals", value="Canada")],
+    )
+    cfg = _config_with_matching(profile)
+    candidates = [
+        _buyer_candidate("buyer-a", score=0.99, fields={"country": "USA"}),      # gated out
+        _buyer_candidate("buyer-b", score=0.50, fields={"country": "Canada"}),   # passes
+    ]
+    with patch.object(matching.profiles_repo, "get_profile_by_id", new=AsyncMock(return_value=_producer_profile())), \
+         patch.object(matching.vector_service, "get_profile_embedding", new=AsyncMock(return_value=[0.1] * 1536)), \
+         patch.object(matching.vector_service, "find_similar_profiles", new=AsyncMock(return_value=candidates)):
+        out = await matching.suggested_matches(
+            cfg, profile_id="p-1", type_slug="producer", viewer={"_id": "u-1", "role": "user"})
+
+    # Highest vector score is gated out, so it must NOT appear in ranked results.
+    assert [r["id"] for r in out["results"]] == ["buyer-b"]
+    assert out["total"] == 1
+    assert len(out["gated"]) == 1
+    g = out["gated"][0]
+    assert g["id"] == "buyer-a" and g["gated"] is True
+    assert g["gate_failures"] == ["ca_only"]
+    failed = [x for x in g["score_breakdown"]["gates"] if not x["passed"]]
+    assert failed and "country" in failed[0]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_config_driven_output_validates_against_response_model():
+    # Guards the API contract: the config-driven shape (slots/gates/gated) must
+    # pass the endpoint's response_model, which the legacy shape's required
+    # field_overlap would otherwise reject.
+    from app.modules.discovery.schemas import SuggestedMatchesResponse
+
+    profile = MatchProfile(
+        vector_weight=0.6,
+        slots=[MatchSlot(name="geo", fields=["country"], comparator="scalar_eq", weight=0.4)],
+        hard_gates=[HardGate(name="ca_only", field="country", op="equals", value="Canada")],
+    )
+    cfg = _config_with_matching(profile)
+    candidates = [
+        _buyer_candidate("buyer-a", score=0.99, fields={"country": "USA"}),
+        _buyer_candidate("buyer-b", score=0.50, fields={"country": "Canada"}),
+    ]
+    with patch.object(matching.profiles_repo, "get_profile_by_id", new=AsyncMock(return_value=_producer_profile())), \
+         patch.object(matching.vector_service, "get_profile_embedding", new=AsyncMock(return_value=[0.1] * 1536)), \
+         patch.object(matching.vector_service, "find_similar_profiles", new=AsyncMock(return_value=candidates)):
+        out = await matching.suggested_matches(
+            cfg, profile_id="p-1", type_slug="producer", viewer={"_id": "u-1", "role": "user"})
+
+    validated = SuggestedMatchesResponse(**out)
+    assert validated.results[0].score_breakdown.slots["geo"].weight == 0.4
+    assert validated.gated[0].gate_failures == ["ca_only"]

--- a/docs/marketplace-configuration.md
+++ b/docs/marketplace-configuration.md
@@ -226,6 +226,41 @@ Each rule:
 | `ai.profile_similarity_threshold` | float (0..1) | Minimum vector similarity score in strict mode |
 | `ai.max_vector_candidates` | int (`>= 1`) | Max vector candidates used during ranking |
 
+#### `discovery.matching` — suggested-match scoring & gates (optional)
+
+Controls how `/api/roles/{type}/{id}/matches` scores and filters counterpart
+profiles. **Omit it and the engine uses its legacy blend** (semantic similarity +
+mean field overlap), so existing configs are unaffected. When present, the
+composite is `vector_weight · vector + Σ slot.weight · slot_score`, and any
+candidate that fails a **hard gate** is excluded from `results` and returned
+(flagged, with reasons) in a separate `gated` list.
+
+```yaml
+discovery:
+  matching:
+    default:                     # weight table used for any target type…
+      vector_weight: 0.6         # semantic-similarity contribution
+      slots:                     # weighted soft dimensions
+        - name: geography
+          fields: [country]
+          comparator: scalar_eq  # scalar_eq | jaccard | numeric_proximity
+          weight: 0.4
+      hard_gates:                # mandatory conditions; failing one excludes the match
+        - name: accreditation
+          field: iso_17025_accredited
+          op: equals             # equals | in | gte | lte | present
+          value: true
+    per_target:                  # …optionally overridden per counterpart type
+      facilitator:
+        vector_weight: 1.0
+```
+
+`vector_weight` plus all `slot.weight`s **must sum to 1.0**. Slot/gate `fields`
+must exist in a profile schema. Each match result carries a `score_breakdown`
+(the vector score, each slot's score/weight, and per-gate pass/fail with a reason)
+so the "why matched / why gated out" is fully explained by the engine — no
+scoring logic lives in the frontend.
+
 ## Cross-Validation Rules
 
 The config is validated at load time. The following constraints are enforced:
@@ -242,6 +277,8 @@ The config is validated at load time. The following constraints are enforced:
 10. `select`/`multi_select` fields must have **`options`** defined
 11. `ai.profile_similarity_threshold` must be within **0..1**
 12. `ai.max_vector_candidates` must be **>= 1**
+13. `discovery.matching` weights (`vector_weight` + slot weights) must **sum to 1.0**; slot names unique
+14. `discovery.matching` slot/gate **fields must exist** in a profile schema; `per_target` keys must be valid type slugs
 
 ## CLI Validation
 


### PR DESCRIPTION
Implements **GAP-3** — config-driven match scoring and hard gates — replacing the hardcoded `VECTOR_WEIGHT 0.7 / FIELD_OVERLAP_WEIGHT 0.3` blend in `suggested_matches`.

## What it adds
A `discovery.matching` config block (optional, **backward-compatible** — omit it and the legacy blend runs unchanged):

```yaml
discovery:
  matching:
    default:
      vector_weight: 0.6
      slots:
        - { name: geography, fields: [country], comparator: scalar_eq, weight: 0.4 }
      hard_gates:
        - { name: accreditation, field: iso_17025_accredited, op: equals, value: true }
    per_target:
      facilitator: { vector_weight: 1.0 }
```

- **Weighted slots.** `composite = vector_weight·vector + Σ slot.weight·slot_score`, with `scalar_eq` / `jaccard` / `numeric_proximity` comparators. Weights must sum to `1.0` (validated).
- **Hard gates.** `equals / in / gte / lte / present`. A candidate failing a gate is **excluded from `results`** and returned flagged (with reasons) in a separate **`gated`** list — so the escape-hatch/pull-signal layer (GAP-14) has a hook later, and "why gated out" is visible now.
- **Per-target weight tables** (`per_target` overrides `default`).
- **Explanation on every result** — `score_breakdown` carries the vector score, each slot's score/weight, and per-gate pass/fail + reason. All scoring is engine-side; **no scoring logic in the frontend**.
- **Validation.** Slot/gate fields must exist in a profile schema; `per_target` keys must be valid participant types; weights sum to 1; slot names unique.

## Design notes
This is the first, deterministic slice of the integrated-matching vision (semantic → CommonContext gates → escape hatches → Generative Match Story). 

## Testing
`test_matching_gap3.py` (15 tests): comparators, gate operators, config validation (weight-sum, unknown field/type, duplicate slot), config-driven ranking, hard-gate exclusion + explanation, and that the config-driven output validates against the endpoint's `response_model` (the shape that would otherwise 500). **Full unit suite passes** (342; the one failure is the pre-existing Windows-only compiler path-sep test, green on Linux). Ruff clean.

Docs: a `discovery.matching` section in `docs/marketplace-configuration.md`.
