### PR TITLE
C0 synthetic population ingest + boundary watermark enforcement (GAP-10/9)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,6 +18,9 @@ class Settings(BaseSettings):
 
     # Session
     session_secret: str = "change-me"
+    # Shared HMAC key for the synthetic-population watermark (GAP-9). ClientSynth
+    # signs synthetic records with this same secret; the ingest boundary verifies it.
+    synthetic_watermark_secret: str = "change-me-synthetic"
     session_ttl_hours: int = 72
     # When False, the session cookie omits the Secure flag so it is stored over
     # plain http from any host (127.0.0.1, LAN IPs). Keep True in production.

--- a/backend/app/core/watermark.py
+++ b/backend/app/core/watermark.py
@@ -1,0 +1,64 @@
+"""Synthetic-population watermarking (GAP-9).
+
+Every synthetic participant record carries a tamper-evident watermark so the
+ingest boundary can (a) reject unwatermarked synthetic data in demo/synthetic
+mode and (b) reject watermarked data in production — the clean-cutover rule,
+enforced in the data layer rather than by convention.
+
+The watermark is an HMAC-SHA256 over the record's stable content (participant
+type + external id + fields), keyed by a shared secret. ClientSynth signs with
+the same secret+algorithm; ``sign`` here is the reference implementation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any
+
+WATERMARK_ALGO = "hmac-sha256-v1"
+WATERMARK_KEY = "_watermark"
+
+
+def _canonical_payload(record: dict[str, Any]) -> bytes:
+    """Deterministic bytes of the record's signed content (excludes the watermark
+    itself), so signing and verification always agree regardless of key order."""
+    signed = {
+        "participant_type": record.get("participant_type"),
+        "external_id": record.get("external_id"),
+        "fields": record.get("fields", {}) or {},
+    }
+    return json.dumps(signed, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sign(record: dict[str, Any], secret: str) -> str:
+    """Return the hex HMAC-SHA256 signature for a record."""
+    return hmac.new(secret.encode("utf-8"), _canonical_payload(record), hashlib.sha256).hexdigest()
+
+
+def stamp(record: dict[str, Any], secret: str) -> dict[str, Any]:
+    """Return a copy of ``record`` with a valid watermark attached."""
+    out = dict(record)
+    out[WATERMARK_KEY] = {"synthetic": True, "algo": WATERMARK_ALGO, "signature": sign(record, secret)}
+    return out
+
+
+def is_watermarked(record: dict[str, Any]) -> bool:
+    """True if the record carries a watermark block (valid or not)."""
+    wm = record.get(WATERMARK_KEY)
+    return isinstance(wm, dict) and bool(wm.get("signature"))
+
+
+def verify(record: dict[str, Any], secret: str) -> bool:
+    """True only if the record carries a well-formed watermark whose signature
+    matches the record's content under ``secret`` (constant-time compare)."""
+    wm = record.get(WATERMARK_KEY)
+    if not isinstance(wm, dict):
+        return False
+    if wm.get("algo") != WATERMARK_ALGO:
+        return False
+    signature = wm.get("signature")
+    if not isinstance(signature, str) or not signature:
+        return False
+    return hmac.compare_digest(signature, sign(record, secret))

--- a/backend/app/modules/population/__init__.py
+++ b/backend/app/modules/population/__init__.py
@@ -1,0 +1,1 @@
+"""C0 file-based synthetic population ingest with boundary watermark enforcement (GAP-10/9)."""

--- a/backend/app/modules/population/loader.py
+++ b/backend/app/modules/population/loader.py
@@ -1,0 +1,29 @@
+"""Parse a C0 population file into raw records.
+
+Accepts a top-level JSON list, or an object carrying the list under
+``records`` / ``population`` / ``profiles``. Pure (no I/O) except the file read.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_LIST_KEYS = ("records", "population", "profiles")
+
+
+def parse_population_text(text: str) -> list[dict[str, Any]]:
+    data = json.loads(text)
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in _LIST_KEYS:
+            if isinstance(data.get(key), list):
+                return data[key]
+        raise ValueError(f"population object must contain one of {_LIST_KEYS} as a list")
+    raise ValueError("population file must be a JSON list or an object with a records list")
+
+
+def load_population_file(path: str | Path) -> list[dict[str, Any]]:
+    return parse_population_text(Path(path).read_text(encoding="utf-8"))

--- a/backend/app/modules/population/repository.py
+++ b/backend/app/modules/population/repository.py
@@ -1,0 +1,78 @@
+"""Persistence for synthetic population profiles.
+
+Kept separate from the participant-facing profiles repository: synthetic profiles
+are keyed by a stable ``external_id`` (so re-imports upsert in place) and own a
+synthetic user, and every record is flagged ``is_synthetic`` for the clean-cutover
+guarantees.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from app.core.database import get_collection
+
+
+async def create_synthetic_user(external_id: str, participant_type: str) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    doc = {
+        "email": f"synthetic+{external_id}@population.local",
+        "participant_type": participant_type,
+        "role": "user",
+        "is_active": True,
+        "has_onboarded": True,
+        "is_synthetic": True,
+        "external_id": external_id,
+        "created_at": now,
+    }
+    result = await get_collection("users").insert_one(doc)
+    doc["_id"] = result.inserted_id
+    return doc
+
+
+async def upsert_synthetic_profile(
+    external_id: str, participant_type: str, fields: dict[str, Any], completeness: int
+) -> tuple[dict[str, Any], bool]:
+    """Insert a new synthetic profile (creating its owner user) or update the
+    existing one with the same ``external_id``. Returns (profile, created)."""
+    profiles = get_collection("profiles")
+    now = datetime.now(timezone.utc)
+
+    existing = await profiles.find_one({"external_id": external_id})
+    if existing:
+        await profiles.update_one(
+            {"external_id": external_id},
+            {"$set": {
+                "participant_type": participant_type,
+                "fields": fields,
+                "completeness": completeness,
+                "updated_at": now,
+            }},
+        )
+        existing.update({"participant_type": participant_type, "fields": fields, "completeness": completeness})
+        return existing, False
+
+    user = await create_synthetic_user(external_id, participant_type)
+    doc = {
+        "user_id": str(user["_id"]),
+        "participant_type": participant_type,
+        "status": "active",
+        "fields": fields,
+        "ai_profile": None,
+        "ai_profile_draft": None,
+        "ai_profile_status": "none",
+        "ai_profile_updated_at": None,
+        "completeness": completeness,
+        "is_synthetic": True,
+        "external_id": external_id,
+        "created_at": now,
+        "updated_at": now,
+    }
+    result = await profiles.insert_one(doc)
+    doc["_id"] = result.inserted_id
+    return doc, True
+
+
+async def count_synthetic_profiles() -> int:
+    return await get_collection("profiles").count_documents({"is_synthetic": True})

--- a/backend/app/modules/population/schemas.py
+++ b/backend/app/modules/population/schemas.py
@@ -1,0 +1,16 @@
+"""Pydantic models for population ingest."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PopulationImportResult(BaseModel):
+    mode: str
+    total: int
+    loaded: int = 0             # newly created synthetic profiles
+    updated: int = 0           # existing external_id upserted in place
+    rejected_watermark: int = 0  # failed the GAP-9 watermark gate
+    skipped_invalid: int = 0    # failed structural / schema validation
+    indexed: int = 0
+    errors: list[str] = Field(default_factory=list)

--- a/backend/app/modules/population/service.py
+++ b/backend/app/modules/population/service.py
@@ -1,0 +1,103 @@
+"""Population import service (GAP-10) with boundary watermark enforcement (GAP-9).
+
+For each record: enforce the watermark per mode, validate its fields against the
+marketplace profile schema, idempotently upsert the synthetic profile, and index
+it into pgvector — reusing the existing validation and indexing code paths.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from pydantic import ValidationError
+
+from app.core import watermark
+from app.core.config import settings
+from app.core.marketplace_config import MarketplaceConfig
+from app.engine.schema_engine import compute_completeness, validate_profile_fields
+from app.modules.discovery.indexer import index_profile
+from app.modules.population import repository as repo
+from app.modules.population.schemas import PopulationImportResult
+
+logger = logging.getLogger("cosolvent.population")
+
+Mode = Literal["demo", "production"]
+
+
+def _watermark_rejection(rec: dict[str, Any], mode: Mode, secret: str) -> str | None:
+    """Return a rejection reason if the record fails the mode's watermark rule, else None."""
+    if mode == "production":
+        # Clean cutover: no synthetic data in production.
+        if watermark.is_watermarked(rec):
+            return "watermarked (synthetic) record rejected in production mode"
+        return None
+    # demo / synthetic mode: every record must carry a valid watermark.
+    if watermark.verify(rec, secret):
+        return None
+    return "invalid synthetic watermark" if watermark.is_watermarked(rec) else "missing synthetic watermark"
+
+
+async def import_population(
+    config: MarketplaceConfig,
+    records: list[dict[str, Any]],
+    *,
+    mode: Mode = "demo",
+    secret: str | None = None,
+    do_index: bool = True,
+) -> PopulationImportResult:
+    secret = secret if secret is not None else settings.synthetic_watermark_secret
+    res = PopulationImportResult(mode=mode, total=len(records))
+
+    for i, rec in enumerate(records):
+        if not isinstance(rec, dict):
+            res.skipped_invalid += 1
+            res.errors.append(f"record {i}: not a JSON object")
+            continue
+        pt = rec.get("participant_type")
+        ext = rec.get("external_id")
+        fields = rec.get("fields")
+        if not pt or not ext or not isinstance(fields, dict):
+            res.skipped_invalid += 1
+            res.errors.append(f"record {i}: missing participant_type / external_id / fields")
+            continue
+
+        # ── GAP-9: watermark gate at the ingest boundary ──
+        reason = _watermark_rejection(rec, mode, secret)
+        if reason:
+            res.rejected_watermark += 1
+            res.errors.append(f"{ext}: {reason}")
+            continue
+
+        # ── schema validation (reuse the participant-facing validator) ──
+        if config.get_type(pt) is None or pt not in config.profile_schemas:
+            res.skipped_invalid += 1
+            res.errors.append(f"{ext}: unknown participant_type '{pt}'")
+            continue
+        try:
+            validated = validate_profile_fields(config, pt, fields)
+        except ValidationError as exc:
+            res.skipped_invalid += 1
+            res.errors.append(f"{ext}: field validation failed ({exc.error_count()} error(s))")
+            continue
+        completeness = compute_completeness(config, pt, validated)
+
+        profile, created = await repo.upsert_synthetic_profile(ext, pt, validated, completeness)
+        if created:
+            res.loaded += 1
+        else:
+            res.updated += 1
+
+        if do_index:
+            try:
+                await index_profile(profile, config)
+                res.indexed += 1
+            except Exception:  # noqa: BLE001 - a single indexing failure must not abort the import.
+                logger.warning("Indexing failed for synthetic profile %s", ext, exc_info=True)
+                res.errors.append(f"{ext}: indexing failed (loaded, will need re-index)")
+
+    logger.info(
+        "Population import (%s): loaded=%d updated=%d rejected_watermark=%d skipped_invalid=%d indexed=%d",
+        mode, res.loaded, res.updated, res.rejected_watermark, res.skipped_invalid, res.indexed,
+    )
+    return res

--- a/backend/cli/__main__.py
+++ b/backend/cli/__main__.py
@@ -104,12 +104,44 @@ def main() -> None:
     refs_parser.add_argument("file", help="Path to the ingestion JSONL export")
     refs_parser.add_argument("--vertical", help="Default vertical if records omit it")
 
+    pop_parser = subparsers.add_parser(
+        "load-population",
+        help="Load a C0 synthetic population file (watermark-enforced) into profiles",
+    )
+    pop_parser.add_argument("file", help="Path to the population JSON file")
+    pop_parser.add_argument("--config", default=None, help="marketplace.yaml path (default: settings)")
+    pop_parser.add_argument(
+        "--mode", choices=["demo", "production"], default="demo",
+        help="demo requires valid watermarks; production rejects watermarked records",
+    )
+    pop_parser.add_argument("--no-index", action="store_true", help="Skip embedding/indexing")
+
+    stamp_parser = subparsers.add_parser(
+        "stamp-population",
+        help="Sign a raw population file with synthetic watermarks (reference signer)",
+    )
+    stamp_parser.add_argument("file", help="Path to the raw population JSON file")
+    stamp_parser.add_argument("-o", "--output", required=True, help="Output (watermarked) file path")
+    stamp_parser.add_argument("--secret", default=None, help="Override the watermark secret")
+
     args = parser.parse_args()
 
     if args.command == "load-references":
         from cli.load_references import load_references_file
 
         ok = load_references_file(args.file, args.vertical)
+        sys.exit(0 if ok else 1)
+    if args.command == "load-population":
+        from app.core.config import settings
+        from cli.load_population import load_population
+
+        config_path = args.config or settings.marketplace_config_path
+        ok = load_population(args.file, config_path, mode=args.mode, do_index=not args.no_index)
+        sys.exit(0 if ok else 1)
+    if args.command == "stamp-population":
+        from cli.stamp_population import stamp_population
+
+        ok = stamp_population(args.file, args.output, secret=args.secret)
         sys.exit(0 if ok else 1)
     if args.command == "generate-config":
         from configgen.cli import main as gen_main

--- a/backend/cli/load_population.py
+++ b/backend/cli/load_population.py
@@ -1,0 +1,49 @@
+"""CLI: load a C0 synthetic population file into Cosolvent (GAP-10/9).
+
+    python -m cli load-population population.json --mode demo
+    python -m cli load-population population.json --mode production --no-index
+
+Reads a JSON population file, enforces the synthetic watermark at the boundary
+(demo mode requires a valid watermark; production rejects watermarked records),
+validates each record against the marketplace profile schema, upserts synthetic
+profiles idempotently by ``external_id`` and indexes them into pgvector. Requires
+a running Postgres (POSTGRES_DSN / .env).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+
+async def _run(path: Path, config_path: str, mode: str, do_index: bool):
+    from app.core.database import close_db, connect_db
+    from app.core.marketplace_config import load_marketplace_config
+    from app.modules.population.loader import load_population_file
+    from app.modules.population.service import import_population
+
+    config = load_marketplace_config(config_path)
+    await connect_db()
+    try:
+        records = load_population_file(path)
+        return await import_population(config, records, mode=mode, do_index=do_index)  # type: ignore[arg-type]
+    finally:
+        await close_db()
+
+
+def load_population(path: str, config_path: str, mode: str = "demo", do_index: bool = True) -> bool:
+    p = Path(path)
+    if not p.exists():
+        print(f"File not found: {path}")
+        return False
+    res = asyncio.run(_run(p, config_path, mode, do_index))
+    print(
+        f"[ok] population import ({res.mode}): loaded={res.loaded} updated={res.updated} "
+        f"indexed={res.indexed} rejected_watermark={res.rejected_watermark} "
+        f"skipped_invalid={res.skipped_invalid}"
+    )
+    for e in res.errors[:20]:
+        print(f"  - {e}")
+    if len(res.errors) > 20:
+        print(f"  ... and {len(res.errors) - 20} more")
+    return (res.loaded + res.updated) > 0

--- a/backend/cli/stamp_population.py
+++ b/backend/cli/stamp_population.py
@@ -1,0 +1,28 @@
+"""CLI: stamp a raw population file with synthetic watermarks (GAP-9 reference signer).
+
+    python -m cli stamp-population raw.json -o population.json
+
+This is the reference implementation of the watermark ClientSynth attaches to its
+exported synthetic records. It reads a population file whose records have
+``participant_type`` / ``external_id`` / ``fields`` and writes a copy with a valid
+``_watermark`` on each, signed with the shared secret (synthetic_watermark_secret).
+No database required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def stamp_population(in_path: str, out_path: str, secret: str | None = None) -> bool:
+    from app.core import watermark
+    from app.core.config import settings
+    from app.modules.population.loader import load_population_file
+
+    key = secret or settings.synthetic_watermark_secret
+    records = load_population_file(in_path)
+    stamped = [watermark.stamp(r, key) if isinstance(r, dict) else r for r in records]
+    Path(out_path).write_text(json.dumps(stamped, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"[ok] stamped {len(stamped)} record(s) -> {out_path}")
+    return True

--- a/backend/tests/integration/test_population_roundtrip.py
+++ b/backend/tests/integration/test_population_roundtrip.py
@@ -1,0 +1,90 @@
+"""Live pgvector round-trip for C0 population ingest (GAP-10) + watermark gating (GAP-9).
+
+Deterministic, provider-free: embeddings are stubbed with a content-derived
+vector, so the full ingest path (validate -> upsert synthetic profile + user ->
+index into profile_vectors -> retrieve) runs against a real migrated database
+without an embedding provider.
+
+Gated by RUN_INTEGRATION.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core import watermark
+from app.core.database import close_db, connect_db, get_collection
+from app.core.marketplace_config import load_marketplace_config
+from app.modules.discovery import vector_service
+from app.modules.population.service import import_population
+from tests.e2e.helpers import require_mode
+
+FIXTURES = Path(__file__).parent.parent / "test_config"
+SECRET = "it-watermark-secret"
+DIM = 1536
+
+_POP = [
+    {"participant_type": "producer", "external_id": "it-prod-1",
+     "fields": {"farm_name": "North Ridge Farms", "country": "Canada", "primary_crops": ["Wheat", "Barley"]}},
+    {"participant_type": "buyer", "external_id": "it-buyer-1", "fields": {"org_name": "Acme Mills"}},
+]
+
+
+def _vec_for(text: str) -> list[float]:
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    base = [b / 255.0 for b in digest]  # 32 values in [0,1]
+    v = (base * (DIM // len(base) + 1))[:DIM]
+    norm = sum(x * x for x in v) ** 0.5 or 1.0
+    return [x / norm for x in v]
+
+
+async def _cleanup():
+    for r in _POP:
+        await get_collection("profiles").delete_one({"external_id": r["external_id"]})
+        await get_collection("users").delete_one({"external_id": r["external_id"]})
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_population_import_roundtrip():
+    require_mode("RUN_INTEGRATION")
+    cfg = load_marketplace_config(FIXTURES / "agriculture.yaml")
+    stamped = [watermark.stamp(r, SECRET) for r in _POP]
+
+    await connect_db()
+    try:
+        await _cleanup()
+
+        with patch("app.modules.discovery.indexer.get_embedding",
+                   new=AsyncMock(side_effect=lambda text: _vec_for(text))):
+            # 1. Import demo + index: both records land and are indexed.
+            res = await import_population(cfg, stamped, mode="demo", secret=SECRET, do_index=True)
+            assert res.loaded == 2 and res.indexed == 2 and res.rejected_watermark == 0, res
+
+            prof = await get_collection("profiles").find_one({"external_id": "it-prod-1"})
+            assert prof and prof.get("is_synthetic") is True and prof["participant_type"] == "producer"
+
+            # 2. The indexed vector is retrievable via the same search matching uses.
+            hits = await vector_service.find_similar_profiles(
+                embedding=_vec_for("[producer] North Ridge Farms Wheat Barley"),
+                participant_types=["producer"], exclude_profile_ids=[], min_score=0.0, limit=10)
+            assert any(h["id"] == str(prof["_id"]) for h in hits)
+
+            # 3. Idempotent re-import: no new profiles, updated in place.
+            res2 = await import_population(cfg, stamped, mode="demo", secret=SECRET, do_index=True)
+            assert res2.updated == 2 and res2.loaded == 0
+
+        # 4. Demo mode rejects unwatermarked records.
+        res3 = await import_population(cfg, _POP, mode="demo", secret=SECRET, do_index=False)
+        assert res3.rejected_watermark == 2 and res3.loaded == 0
+
+        # 5. Production mode rejects watermarked (synthetic) records — clean cutover.
+        res4 = await import_population(cfg, stamped, mode="production", secret=SECRET, do_index=False)
+        assert res4.rejected_watermark == 2 and res4.loaded == 0
+    finally:
+        await _cleanup()
+        await close_db()

--- a/backend/tests/unit/test_population.py
+++ b/backend/tests/unit/test_population.py
@@ -1,0 +1,133 @@
+"""Unit tests for the population import service (GAP-10) + watermark gating (GAP-9).
+
+Persistence + indexing are mocked; validation uses the real agriculture config.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core import watermark
+from app.core.marketplace_config import load_marketplace_config
+from app.modules.population import service
+from app.modules.population.loader import parse_population_text
+
+FIXTURES = Path(__file__).parent.parent / "test_config"
+SECRET = "test-secret"
+
+
+def _cfg():
+    return load_marketplace_config(FIXTURES / "agriculture.yaml")
+
+
+def _producer(ext: str, country: str = "Canada", crops=None) -> dict:
+    return {"participant_type": "producer", "external_id": ext,
+            "fields": {"farm_name": f"Farm {ext}", "country": country, "primary_crops": crops or ["Wheat"]}}
+
+
+@contextmanager
+def _mock_persist(created: bool = True):
+    async def _upsert(external_id, participant_type, fields, completeness):
+        return {"_id": external_id, "participant_type": participant_type, "fields": fields}, created
+    with patch.object(service.repo, "upsert_synthetic_profile", side_effect=_upsert) as up, \
+         patch.object(service, "index_profile", new=AsyncMock()) as idx:
+        yield up, idx
+
+
+async def _run(records, mode="demo", do_index=False, created=True):
+    with _mock_persist(created=created):
+        return await service.import_population(_cfg(), records, mode=mode, secret=SECRET, do_index=do_index)
+
+
+# ── loader ────────────────────────────────────────────────────────────────
+
+def test_loader_accepts_list_and_records_object():
+    assert parse_population_text('[{"a":1}]') == [{"a": 1}]
+    assert parse_population_text('{"records":[{"a":1}]}') == [{"a": 1}]
+    with pytest.raises(ValueError):
+        parse_population_text('{"nope": 1}')
+
+
+# ── demo mode: watermark required ─────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_demo_rejects_unwatermarked():
+    res = await _run([_producer("s1")])  # no watermark
+    assert res.rejected_watermark == 1 and res.loaded == 0
+    assert "missing synthetic watermark" in res.errors[0]
+
+
+@pytest.mark.asyncio
+async def test_demo_accepts_valid_watermark():
+    res = await _run([watermark.stamp(_producer("s1"), SECRET)])
+    assert res.loaded == 1 and res.rejected_watermark == 0 and res.skipped_invalid == 0
+
+
+@pytest.mark.asyncio
+async def test_demo_rejects_tampered_watermark():
+    rec = watermark.stamp(_producer("s1"), SECRET)
+    rec["fields"]["country"] = "USA"  # tamper after signing
+    res = await _run([rec])
+    assert res.rejected_watermark == 1
+    assert "invalid synthetic watermark" in res.errors[0]
+
+
+# ── production mode: clean cutover ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_production_rejects_watermarked():
+    res = await _run([watermark.stamp(_producer("s1"), SECRET)], mode="production")
+    assert res.rejected_watermark == 1 and res.loaded == 0
+
+
+@pytest.mark.asyncio
+async def test_production_accepts_unwatermarked_real_record():
+    res = await _run([_producer("real-1")], mode="production")  # no watermark = real data
+    assert res.loaded == 1 and res.rejected_watermark == 0
+
+
+# ── schema validation ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_invalid_field_type_skipped():
+    # primary_crops is multi_select (a list); a scalar violates the schema.
+    bad = {"participant_type": "producer", "external_id": "s1",
+           "fields": {"farm_name": "F", "country": "Canada", "primary_crops": "Wheat"}}
+    res = await _run([watermark.stamp(bad, SECRET)])
+    assert res.skipped_invalid == 1 and res.loaded == 0
+    assert "validation failed" in res.errors[0]
+
+
+@pytest.mark.asyncio
+async def test_unknown_participant_type_skipped():
+    rec = watermark.stamp({"participant_type": "ghost", "external_id": "g1", "fields": {}}, SECRET)
+    res = await _run([rec])
+    assert res.skipped_invalid == 1
+    assert "unknown participant_type" in res.errors[0]
+
+
+@pytest.mark.asyncio
+async def test_missing_required_keys_skipped():
+    res = await _run([{"external_id": "x", "fields": {}}])  # no participant_type
+    assert res.skipped_invalid == 1
+
+
+# ── idempotency + indexing ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_reimport_counts_as_updated():
+    res = await _run([watermark.stamp(_producer("s1"), SECRET)], created=False)
+    assert res.updated == 1 and res.loaded == 0
+
+
+@pytest.mark.asyncio
+async def test_indexing_invoked_when_enabled():
+    with _mock_persist() as (_up, idx):
+        res = await service.import_population(
+            _cfg(), [watermark.stamp(_producer("s1"), SECRET)], mode="demo", secret=SECRET, do_index=True)
+    assert res.indexed == 1
+    idx.assert_awaited_once()

--- a/backend/tests/unit/test_watermark.py
+++ b/backend/tests/unit/test_watermark.py
@@ -1,0 +1,52 @@
+"""Unit tests for the synthetic-population watermark (GAP-9)."""
+
+from __future__ import annotations
+
+from app.core import watermark
+
+SECRET = "test-secret"
+
+
+def _rec() -> dict:
+    return {"participant_type": "producer", "external_id": "syn-1",
+            "fields": {"farm_name": "North Ridge", "crops": ["Wheat", "Barley"]}}
+
+
+def test_stamp_and_verify_roundtrip():
+    r = watermark.stamp(_rec(), SECRET)
+    assert watermark.is_watermarked(r)
+    assert watermark.verify(r, SECRET)
+    assert r["_watermark"]["algo"] == watermark.WATERMARK_ALGO
+
+
+def test_unwatermarked_record_fails_verify():
+    assert not watermark.is_watermarked(_rec())
+    assert not watermark.verify(_rec(), SECRET)
+
+
+def test_wrong_secret_fails():
+    assert not watermark.verify(watermark.stamp(_rec(), SECRET), "other-secret")
+
+
+def test_tampered_fields_fail():
+    r = watermark.stamp(_rec(), SECRET)
+    r["fields"]["farm_name"] = "Someone Else"  # tamper after signing
+    assert not watermark.verify(r, SECRET)
+
+
+def test_tampered_external_id_fails():
+    r = watermark.stamp(_rec(), SECRET)
+    r["external_id"] = "syn-2"
+    assert not watermark.verify(r, SECRET)
+
+
+def test_unknown_algo_rejected():
+    r = watermark.stamp(_rec(), SECRET)
+    r["_watermark"]["algo"] = "md5"
+    assert not watermark.verify(r, SECRET)
+
+
+def test_signature_is_field_order_independent():
+    r1 = {"participant_type": "p", "external_id": "e", "fields": {"a": 1, "b": 2}}
+    r2 = {"participant_type": "p", "external_id": "e", "fields": {"b": 2, "a": 1}}
+    assert watermark.sign(r1, SECRET) == watermark.sign(r2, SECRET)

--- a/docs/population-ingest.md
+++ b/docs/population-ingest.md
@@ -1,0 +1,66 @@
+# Synthetic Population Ingest (C0) + Watermarking
+
+Bulk-load a synthetic participant population from a file into Cosolvent, with the
+synthetic watermark **enforced at the ingest boundary** — the mechanism that lets
+a Mode-2 market run against a loaded synthetic population and guarantees the clean
+cutover to real users (GAP-10 / GAP-9).
+
+## The population file
+
+A JSON list (or an object with a `records` / `population` / `profiles` list). Each
+record is one participant:
+
+```json
+[
+  {
+    "participant_type": "producer",
+    "external_id": "cs-prod-001",
+    "fields": { "farm_name": "North Ridge Farms", "country": "Canada", "primary_crops": ["Wheat", "Barley"] },
+    "_watermark": { "synthetic": true, "algo": "hmac-sha256-v1", "signature": "…" }
+  }
+]
+```
+
+- `participant_type` — a marketplace participant type slug.
+- `external_id` — a stable id; re-importing the same id **upserts in place** (idempotent).
+- `fields` — validated against that type's `profile_schema` (same validator as participant registration).
+- `_watermark` — the synthetic marker (see below); attached by ClientSynth, or by `stamp-population`.
+
+## The watermark (GAP-9)
+
+The watermark is an **HMAC-SHA256** over the record's stable content
+(`participant_type` + `external_id` + `fields`), keyed by a shared secret
+(`SYNTHETIC_WATERMARK_SECRET`). It is tamper-evident: changing any signed field
+invalidates the signature. ClientSynth signs its export with the same secret and
+algorithm; `stamp-population` is the reference signer.
+
+**Boundary enforcement is mode-aware:**
+
+| Mode | Rule |
+|------|------|
+| `demo` (synthetic) | Every record **must** carry a valid watermark; unwatermarked or tampered records are rejected. |
+| `production` | Any **watermarked** (synthetic) record is rejected — the clean cutover, enforced in the data layer, not by convention. |
+
+## CLI
+
+```bash
+# 1. Sign a raw population file (reference signer; simulates ClientSynth's output)
+python -m cli stamp-population raw.json -o population.json         # uses SYNTHETIC_WATERMARK_SECRET
+
+# 2. Load it into the synthetic population
+python -m cli load-population population.json --mode demo          # validate + upsert + index
+python -m cli load-population population.json --mode demo --no-index   # load without embedding/indexing
+```
+
+`load-population` requires a running Postgres (`POSTGRES_DSN` / `.env`) and a
+`marketplace.yaml` (via `--config`, default from settings). For each record it:
+enforces the watermark → validates fields against the schema → upserts a synthetic
+profile (owned by a synthetic user, flagged `is_synthetic`, keyed by `external_id`)
+→ generates an embedding and indexes it into `profile_vectors` (reusing the normal
+indexer). Output reports `loaded / updated / indexed / rejected_watermark /
+skipped_invalid` counts.
+
+## Config
+
+- `SYNTHETIC_WATERMARK_SECRET` — the shared HMAC key (must match ClientSynth's).
+- Mode is an explicit per-run flag (`--mode`), never a silent global default.


### PR DESCRIPTION
Implements the ClientSynth→Cosolvent population substrate that the deal, matching, and gating paths currently lack, with the synthetic watermark enforced at the ingest boundary.

## What it adds
**C0 file-based ingest** :
- Parses a `population.json` (list, or `{records:[…]}`), then per record: **watermark gate → schema validation → idempotent upsert → pgvector index**, reusing the existing `validate_profile_fields` and profile indexer.
- Synthetic profiles are keyed by a stable `external_id` (re-import upserts in place), owned by a synthetic user, and flagged `is_synthetic`.
- Reports `loaded / updated / rejected_watermark / skipped_invalid / indexed`.

**Watermark** — tamper-evident **HMAC-SHA256** over each record's stable content (`participant_type + external_id + fields`), keyed by a shared secret. Enforced mode-aware at the boundary, in the data layer:
| Mode | Rule |
|------|------|
| `demo` | every record **must** carry a valid watermark (unwatermarked/tampered → rejected) |
| `production` | any **watermarked** record is rejected — the clean cutover |

**`stamp-population`** CLI is the reference signer (the marker ClientSynth attaches to its export). `SYNTHETIC_WATERMARK_SECRET` is the shared key.

## Verified end-to-end 
- **Live pgvector integration test** (`test_population_roundtrip`): stamp → import demo+index (loaded=2, indexed=2) → the indexed vector is **retrievable via the same search matching uses** → idempotent re-import (updated=2, loaded=0) → unwatermarked rejected → production rejects watermarked.
- **Real CLI run** on a fresh DB with a 5-record agriculture population: `stamp` → `load` (loaded=5) → re-load (updated=5) → unwatermarked in demo (rejected=5, exit 1) → watermarked in production (rejected=5, exit 1); 5 synthetic profiles persisted.
- **Unit tests**: watermark sign/verify/tamper (7) + import gating/validation/idempotency (11). **Full unit suite passes** (360; the one failure is the pre-existing Windows-only compiler path-sep test, green on Linux). Ruff clean.

## Open-source tooling
This is deterministic structured-data ingest + validation, so the knowledge/LLM/frontend tools don't fit; the watermark uses **stdlib `hmac`** (the correct primitive, no dependency). 
